### PR TITLE
feat(ibm): add ibm ibm_is_virtual_endpoint_gateway support

### DIFF
--- a/internal/providers/terraform/ibm/registry.go
+++ b/internal/providers/terraform/ibm/registry.go
@@ -24,6 +24,7 @@ var FreeResources = []string{
 	"ibm_is_security_group_rule",
 	"ibm_is_ssh_key",
 	"ibm_is_subnet",
+	"ibm_is_virtual_endpoint_gateway",
 	"ibm_is_virtual_endpoint_gateway_ip",
 	"ibm_is_vpc_address_prefix",
 	"ibm_kms_key",


### PR DESCRIPTION
I think the charges will come through VPC egress, not the virtual endpoint itself. Global catalog had no pricing information