### PR TITLE
feat(ibm): add is vpn gateway connection support

### DIFF
--- a/internal/providers/terraform/ibm/registry.go
+++ b/internal/providers/terraform/ibm/registry.go
@@ -26,6 +26,7 @@ var FreeResources = []string{
 	"ibm_is_subnet",
 	"ibm_is_virtual_endpoint_gateway_ip",
 	"ibm_is_vpc_address_prefix",
+	"ibm_is_vpn_gateway_connection",
 	"ibm_kms_key",
 	"ibm_kms_key_rings",
 	"ibm_resource_group",


### PR DESCRIPTION
I think the thing itself is free, as in the charge comes for the connection hours on the vpn gateway the connection is made to:
https://github.com/IBM-Cloud/infracost/pull/12
see the connections hour metric