### PR TITLE
lint warnings

### DIFF
--- a/internal/resources/ibm/ibm_is_vpc.go
+++ b/internal/resources/ibm/ibm_is_vpc.go
@@ -10,7 +10,6 @@ import (
 
 // IbmIsVpc struct represents an instance of IBM's Virtual Private Cloud
 //
-//
 // Resource information: https://cloud.ibm.com/docs/vpc?topic=vpc-getting-started
 // Pricing information: https://www.ibm.com/cloud/vpc/pricing
 type IbmIsVpc struct {
@@ -40,7 +39,7 @@ func (r *IbmIsVpc) vpcEgressFreeCostComponent() *schema.CostComponent {
 		}
 	}
 	costComponent := schema.CostComponent{
-		Name:            fmt.Sprintf("VPC egress free allowance (first 5GB)"),
+		Name:            "VPC egress free allowance (first 5GB)",
 		Unit:            "GB",
 		UnitMultiplier:  decimal.NewFromInt(1),
 		MonthlyQuantity: quantity,
@@ -85,7 +84,7 @@ func (r *IbmIsVpc) vpcEgressCostComponent() *schema.CostComponent {
 
 func (r *IbmIsVpc) vpcInstanceCostComponent() *schema.CostComponent {
 	return &schema.CostComponent{
-		Name:            fmt.Sprintf("VPC instance"),
+		Name:            "VPC instance",
 		Unit:            "Instance",
 		UnitMultiplier:  decimal.NewFromInt(1),
 		MonthlyQuantity: decimalPtr(decimal.NewFromInt(1)),

--- a/internal/resources/ibm/resource_instance.go
+++ b/internal/resources/ibm/resource_instance.go
@@ -68,7 +68,7 @@ func KMSKeyVersionsFreeCostComponent(r *ResourceInstance) *schema.CostComponent 
 		}
 	}
 	costComponent := schema.CostComponent{
-		Name:            fmt.Sprintf("Key versions free allowance (first 5 Key Versions)"),
+		Name:            "Key versions free allowance (first 5 Key Versions)",
 		Unit:            "Key Versions",
 		UnitMultiplier:  decimal.NewFromInt(1),
 		MonthlyQuantity: q,
@@ -93,7 +93,7 @@ func KMSKeyVersionCostComponents(r *ResourceInstance) *schema.CostComponent {
 		}
 	}
 	costComponent := schema.CostComponent{
-		Name:            fmt.Sprintf("Key versions"),
+		Name:            "Key versions",
 		Unit:            "Key Versions",
 		UnitMultiplier:  decimal.NewFromInt(1),
 		MonthlyQuantity: q,
@@ -122,7 +122,7 @@ func SecretsManagerInstanceCostComponent(r *ResourceInstance) *schema.CostCompon
 		q = decimalPtr(decimal.NewFromInt(*r.SecretsManager_Instance))
 	}
 	costComponent := schema.CostComponent{
-		Name:            fmt.Sprintf("Instance"),
+		Name:            "Instance",
 		Unit:            "Instance",
 		UnitMultiplier:  decimal.NewFromInt(1),
 		MonthlyQuantity: q,
@@ -147,7 +147,7 @@ func SecretsManagerActiveSecretsCostComponent(r *ResourceInstance) *schema.CostC
 		q = decimalPtr(decimal.NewFromInt(*r.SecretsManager_ActiveSecrets))
 	}
 	costComponent := schema.CostComponent{
-		Name:            fmt.Sprintf("Active Secrets"),
+		Name:            "Active Secrets",
 		Unit:            "Secrets",
 		UnitMultiplier:  decimal.NewFromInt(1),
 		MonthlyQuantity: q,
@@ -173,7 +173,7 @@ func GetSecretsManagerCostComponents(r *ResourceInstance) []*schema.CostComponen
 			SecretsManagerActiveSecretsCostComponent(r),
 		}
 	} else {
-		costComponent := *&schema.CostComponent{
+		costComponent := schema.CostComponent{
 			Name: fmt.Sprintf("Plan: %s", r.Plan),
 		}
 		costComponent.SetCustomPrice(decimalPtr(decimal.NewFromInt(0)))
@@ -189,7 +189,7 @@ func AppIDUserCostComponent(r *ResourceInstance) *schema.CostComponent {
 		q = decimalPtr(decimal.NewFromInt(*r.AppID_Users))
 	}
 	costComponent := schema.CostComponent{
-		Name:            fmt.Sprintf("Users"),
+		Name:            "Users",
 		Unit:            "Users",
 		UnitMultiplier:  decimal.NewFromInt(1),
 		MonthlyQuantity: q,
@@ -214,7 +214,7 @@ func AppIDAuthenticationCostComponent(r *ResourceInstance) *schema.CostComponent
 		q = decimalPtr(decimal.NewFromInt(*r.AppID_Authentications))
 	}
 	costComponent := schema.CostComponent{
-		Name:            fmt.Sprintf("Authentications"),
+		Name:            "Authentications",
 		Unit:            "Authentications",
 		UnitMultiplier:  decimal.NewFromInt(1),
 		MonthlyQuantity: q,
@@ -239,7 +239,7 @@ func AppIDAdvancedAuthenticationCostComponent(r *ResourceInstance) *schema.CostC
 		q = decimalPtr(decimal.NewFromInt(*r.AppID_AdvancedAuthentications))
 	}
 	costComponent := schema.CostComponent{
-		Name:            fmt.Sprintf("Advanced Authentications"),
+		Name:            "Advanced Authentications",
 		Unit:            "Authentications",
 		UnitMultiplier:  decimal.NewFromInt(1),
 		MonthlyQuantity: q,
@@ -266,7 +266,7 @@ func GetAppIDCostComponents(r *ResourceInstance) []*schema.CostComponent {
 			AppIDAdvancedAuthenticationCostComponent(r),
 		}
 	} else {
-		costComponent := *&schema.CostComponent{
+		costComponent := schema.CostComponent{
 			Name: fmt.Sprintf("Plan: %s", r.Plan),
 		}
 		costComponent.SetCustomPrice(decimalPtr(decimal.NewFromInt(0)))


### PR DESCRIPTION
- *&x will be simplified to x. It will not copy x. (SA4001) go-staticcheck 
- use literal strings when no formatting used