### PR TITLE
remove hard coded region in pricing search for vpc clusters

### DIFF
--- a/internal/resources/ibm/container_vpc_cluster.go
+++ b/internal/resources/ibm/container_vpc_cluster.go
@@ -96,7 +96,6 @@ func (r *ContainerVpcCluster) BuildResource() *schema.Resource {
 			MonthlyQuantity: decimalPtr(quantity),
 			ProductFilter: &schema.ProductFilter{
 				VendorName:       strPtr("ibm"),
-				Region:           strPtr("us-south"),
 				Service:          strPtr("containers-kubernetes"),
 				AttributeFilters: attributeFilters,
 			},


### PR DESCRIPTION
fixes: https://github.ibm.com/ibmcloud/CostEstimation/issues/260
