### PR TITLE
Add support for Watson Discovery resource

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -72,6 +72,11 @@ resource_type_default_usage:
     wa_instance: 1
     wa_monthly_active_users: 1001
     wa_voice_users: 101
+    wd_instance: 1
+    wd_documents: 10001
+    wd_queries: 10001
+    wd_custom_models: 4
+    wd_collections: 301
   ibm_tg_gateway: 
     connection: 3
     data_transfer_global: 1000
@@ -1302,6 +1307,18 @@ resource_usage:
     wa_instance: 1 # The number of instances used per month where each instance includes 1000 monthly active users
     wa_monthly_active_users: 1100 # The number of monthly active users
     wa_monthly_voice_users: 100 # The number of monthly active voice users
+
+  ibm_resource_instance.watson_discovery_plus:
+    wd_instance: 1 # Number of instances used per month
+    wd_documents: 10001 # Number of monthly documents created; 10,000 included in the Plus plan
+    wd_queries: 10001 # Number of queries documents created; 10,000 included in the Plus plan
+  
+  ibm_resource_instance.watson_discovery_enterprise:
+    wd_instance: 1 # Number of instances used per month
+    wd_documents: 100001 # Number of monthly documents created; 100,000 included in the Enterprise plan
+    wd_queries: 100001 # Number of queries documents created; 100,000 included in the Enterprise plan
+    wd_custom_models: 4 # Number of monthly custom models created; 3 included in the Enterprise plan
+    wd_collections: 301 # Number of monthly collections created; 300 included in the Enterprise plan
 
   ibm_tg_gateway.tg_gateway:
     connection: 25 # Monthly number of connections to the gateway

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -73,8 +73,8 @@ resource_type_default_usage:
     wa_monthly_active_users: 1001
     wa_voice_users: 101
     wd_instance: 1
-    wd_documents: 10001
-    wd_queries: 10001
+    wd_documents: 11000
+    wd_queries: 11000
     wd_custom_models: 4
     wd_collections: 301
   ibm_tg_gateway: 
@@ -1310,15 +1310,15 @@ resource_usage:
 
   ibm_resource_instance.watson_discovery_plus:
     wd_instance: 1 # Number of instances used per month
-    wd_documents: 10001 # Number of monthly documents created; 10,000 included in the Plus plan
-    wd_queries: 10001 # Number of queries documents created; 10,000 included in the Plus plan
+    wd_documents: 11000 # Number of monthly documents created; 10,000 included in the Plus plan; $50 for every additional 1,000 documents.
+    wd_queries: 11000 # Number of queries documents created; 10,000 included in the Plus plan; $20 for every additional 1,000 queries.
   
   ibm_resource_instance.watson_discovery_enterprise:
     wd_instance: 1 # Number of instances used per month
-    wd_documents: 100001 # Number of monthly documents created; 100,000 included in the Enterprise plan
-    wd_queries: 100001 # Number of queries documents created; 100,000 included in the Enterprise plan
-    wd_custom_models: 4 # Number of monthly custom models created; 3 included in the Enterprise plan
-    wd_collections: 301 # Number of monthly collections created; 300 included in the Enterprise plan
+    wd_documents: 101000 # Number of monthly documents created; 100,000 included in the Enterprise plan; $5 for every additional 1,000 documents.
+    wd_queries: 101000 # Number of queries documents created; 100,000 included in the Enterprise plan; $5 for every additional 1,000 queries.
+    wd_custom_models: 4 # Number of monthly custom models created; 3 included in the Enterprise plan; $500 for every additional custom model.
+    wd_collections: 301 # Number of monthly collections created; 300 included in the Enterprise plan. $500 for every additional 100 collections.
 
   ibm_tg_gateway.tg_gateway:
     connection: 25 # Monthly number of connections to the gateway

--- a/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.golden
+++ b/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.golden
@@ -90,6 +90,18 @@
  ibm_resource_instance.wa_instance_trial                                                                                                     
  └─ Trial                                                                                    1                                         $0.00 
                                                                                                                                              
+ ibm_resource_instance.watson_discovery_enterprise                                                                                           
+ ├─ Instance                                                                                 1  Instance                           $5,000.00 
+ ├─ Additional Monthly Documents                                                         1,000  Documents                              $5.00 
+ ├─ Additional Monthly Queries                                                           1,000  Queries                                $5.00 
+ ├─ Additional Monthly Custom Models                                                         1  Custom Models                        $500.00 
+ └─ Additional Monthly Collections                                                           1  Hundred Collections                  $500.00 
+                                                                                                                                             
+ ibm_resource_instance.watson_discovery_plus                                                                                                 
+ ├─ Instance                                                                                 1  Instance                             $500.00 
+ ├─ Additional Monthly Documents                                                         1,000  Documents                             $50.00 
+ └─ Additional Monthly Queries                                                           1,000  Queries                               $20.00 
+                                                                                                                                             
  ibm_resource_instance.wml_instance_essentials                                                                                               
  ├─ Capacity Unit-Hours                                                                     20  CUH                                   $10.40 
  ├─ Class 1 Resource Units                                                                  50  RU                                     $0.03 
@@ -105,7 +117,7 @@
  ├─ Class 2 Resource Units                                                                  50  RU                                     $0.09 
  └─ Class 3 Resource Units                                                                  50  RU                                     $0.25 
                                                                                                                                              
- OVERALL TOTAL                                                                                                                     $8,880.14 
+ OVERALL TOTAL                                                                                                                    $15,460.14 
 ──────────────────────────────────
-23 cloud resources were detected:
-∙ 23 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+25 cloud resources were detected:
+∙ 25 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.tf
+++ b/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.tf
@@ -184,3 +184,19 @@ resource "ibm_resource_instance" "wa_instance_enterprise" {
   location          = "us-south"
   resource_group_id = "default"
 }
+
+resource "ibm_resource_instance" "watson_discovery_plus" {
+  name              = "wd_plus"
+  service           = "discovery"
+  plan              = "plus"
+  location          = "us-south"
+  resource_group_id = "default"
+}
+
+resource "ibm_resource_instance" "watson_discovery_enterprise" {
+  name              = "wd_enterprise"
+  service           = "discovery"
+  plan              = "enterprise"
+  location          = "us-south"
+  resource_group_id = "default"
+}

--- a/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.usage.yml
+++ b/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.usage.yml
@@ -56,3 +56,15 @@ resource_usage:
     wa_instance: 1
     wa_monthly_active_users: 51000
     wa_voice_users: 1000
+
+  ibm_resource_instance.watson_discovery_plus:
+    wd_instance: 1 # Number of instances used per month
+    wd_documents: 10001 # Number of monthly documents created; 10,000 included in the Plus plan
+    wd_queries: 10001 # Number of queries documents created; 10,000 included in the Plus plan
+  
+  ibm_resource_instance.watson_discovery_enterprise:
+    wd_instance: 1 # Number of instances used per month
+    wd_documents: 100001 # Number of monthly documents created; 100,000 included in the Enterprise plan
+    wd_queries: 100001 # Number of queries documents created; 100,000 included in the Enterprise plan
+    wd_custom_models: 4 # Number of monthly custom models created; 3 included in the Enterprise plan
+    wd_collections: 301 # Number of monthly collections created; 300 included in the Enterprise plan

--- a/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.usage.yml
+++ b/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.usage.yml
@@ -59,12 +59,12 @@ resource_usage:
 
   ibm_resource_instance.watson_discovery_plus:
     wd_instance: 1 # Number of instances used per month
-    wd_documents: 10001 # Number of monthly documents created; 10,000 included in the Plus plan
-    wd_queries: 10001 # Number of queries documents created; 10,000 included in the Plus plan
+    wd_documents: 11000 # Number of monthly documents created; 10,000 included in the Plus plan; $50 for every additional 1,000 documents.
+    wd_queries: 11000 # Number of queries documents created; 10,000 included in the Plus plan; $20 for every additional 1,000 queries.
   
   ibm_resource_instance.watson_discovery_enterprise:
     wd_instance: 1 # Number of instances used per month
-    wd_documents: 100001 # Number of monthly documents created; 100,000 included in the Enterprise plan
-    wd_queries: 100001 # Number of queries documents created; 100,000 included in the Enterprise plan
-    wd_custom_models: 4 # Number of monthly custom models created; 3 included in the Enterprise plan
-    wd_collections: 301 # Number of monthly collections created; 300 included in the Enterprise plan
+    wd_documents: 101000 # Number of monthly documents created; 100,000 included in the Enterprise plan; $5 for every additional 1,000 documents.
+    wd_queries: 101000 # Number of queries documents created; 100,000 included in the Enterprise plan; $5 for every additional 1,000 queries.
+    wd_custom_models: 4 # Number of monthly custom models created; 3 included in the Enterprise plan; $500 for every additional custom model.
+    wd_collections: 301 # Number of monthly collections created; 300 included in the Enterprise plan. $500 for every additional 100 collections.

--- a/internal/resources/ibm/resource_instance.go
+++ b/internal/resources/ibm/resource_instance.go
@@ -68,6 +68,12 @@ type ResourceInstance struct {
 	WA_Instance *float64 `infracost_usage:"wa_instance"`
 	WA_mau      *float64 `infracost_usage:"wa_monthly_active_users"`
 	WA_vu       *float64 `infracost_usage:"wa_voice_users"`
+	// Watson Discovery
+	WD_Instance     *float64 `infracost_usage:"wd_instance"`
+	WD_Document     *float64 `infracost_usage:"wd_documents"`
+	WD_Queries      *float64 `infracost_usage:"wd_queries"`
+	WD_CustomModels *float64 `infracost_usage:"wd_custom_models"`
+	WD_Collections  *float64 `infracost_usage:"wd_collections"`
 }
 
 type ResourceCostComponentsFunc func(*ResourceInstance) []*schema.CostComponent
@@ -105,6 +111,11 @@ var ResourceInstanceUsageSchema = []*schema.UsageItem{
 	{Key: "wa_instance", DefaultValue: 0, ValueType: schema.Float64},
 	{Key: "wa_monthly_active_users", DefaultValue: 0, ValueType: schema.Float64},
 	{Key: "wa_voice_users", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "wd_instance", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "wd_documents", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "wd_queries", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "wd_custom_models", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "wd_collections", DefaultValue: 0, ValueType: schema.Float64},
 }
 
 var ResourceInstanceCostMap map[string]ResourceCostComponentsFunc = map[string]ResourceCostComponentsFunc{
@@ -119,6 +130,7 @@ var ResourceInstanceCostMap map[string]ResourceCostComponentsFunc = map[string]R
 	"continuous-delivery": GetContinuousDeliveryCostComponenets,
 	"pm-20":               GetWMLCostComponents,
 	"conversation":        GetWACostComponents,
+	"discovery":           GetWDCostComponents,
 }
 
 func KMSKeyVersionsFreeCostComponent(r *ResourceInstance) *schema.CostComponent {

--- a/internal/resources/ibm/resource_instance.go
+++ b/internal/resources/ibm/resource_instance.go
@@ -70,7 +70,7 @@ type ResourceInstance struct {
 	WA_vu       *float64 `infracost_usage:"wa_voice_users"`
 	// Watson Discovery
 	WD_Instance     *float64 `infracost_usage:"wd_instance"`
-	WD_Document     *float64 `infracost_usage:"wd_documents"`
+	WD_Documents    *float64 `infracost_usage:"wd_documents"`
 	WD_Queries      *float64 `infracost_usage:"wd_queries"`
 	WD_CustomModels *float64 `infracost_usage:"wd_custom_models"`
 	WD_Collections  *float64 `infracost_usage:"wd_collections"`

--- a/internal/resources/ibm/resource_instance_discovery.go
+++ b/internal/resources/ibm/resource_instance_discovery.go
@@ -2,13 +2,14 @@ package ibm
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/infracost/infracost/internal/schema"
 	"github.com/shopspring/decimal"
 )
 
-var ENTERPRISE_PLAN_PROGRAMMATIC_NAME string = "enterprise"
-var PLUS_PLAN_PROGRAMMATIC_NAME string = "plus"
+const ENTERPRISE_PLAN_PROGRAMMATIC_NAME string = "enterprise"
+const PLUS_PLAN_PROGRAMMATIC_NAME string = "plus"
 
 /*
  * Plus = 'plus'
@@ -50,19 +51,19 @@ func GetWDCostComponents(r *ResourceInstance) []*schema.CostComponent {
  */
 func WDInstanceCostComponent(r *ResourceInstance) *schema.CostComponent {
 
-	var quantity *decimal.Decimal
 	var instances_unit_name string
-
-	if r.WD_Instance != nil {
-		quantity = decimalPtr(decimal.NewFromFloat(*r.WD_Instance))
-	} else {
-		quantity = decimalPtr(decimal.NewFromInt(1))
-	}
+	var quantity *decimal.Decimal
 
 	if r.Plan == PLUS_PLAN_PROGRAMMATIC_NAME {
 		instances_unit_name = "PLUS_SERVICE_INSTANCES_PER_MONTH"
 	} else {
 		instances_unit_name = "ENTERPRISE_SERVICE_INSTANCES_PER_MONTH"
+	}
+
+	if r.WD_Instance != nil {
+		quantity = decimalPtr(decimal.NewFromFloat(*r.WD_Instance))
+	} else {
+		quantity = decimalPtr(decimal.NewFromInt(1))
 	}
 
 	return &schema.CostComponent{
@@ -90,8 +91,46 @@ func WDInstanceCostComponent(r *ResourceInstance) *schema.CostComponent {
  * - Enterprise: $USD/documents/month. Includes 100,000 documents per month; $USD for every additional 1,000 documents.
  */
 func WDMonthlyDocumentsCostComponent(r *ResourceInstance) *schema.CostComponent {
+
+	var documents_additional_range int = 1000 // Additional cost for every 1000 over the included amount of documents
+	var documents_included int
+	var documents_unit_name string
 	var quantity *decimal.Decimal
 
+	if r.Plan == PLUS_PLAN_PROGRAMMATIC_NAME {
+		documents_unit_name = "PLUS_DOCUMENTS_TOTAL"
+		documents_included = 10000
+	} else {
+		documents_unit_name = "ENTERPRISE_DOCUMENTS_TOTAL"
+		documents_included = 100000
+	}
+
+	if r.WD_Document != nil {
+
+		additional_documents := *r.WD_Document - float64(documents_included)
+
+		if additional_documents > 0 {
+			quantity = decimalPtr(decimal.NewFromFloat(math.Ceil(additional_documents / float64(documents_additional_range))))
+		}
+	}
+
+	return &schema.CostComponent{
+		Name:            "Additional Monthly Documents",
+		Unit:            "1K documents",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: quantity,
+		ProductFilter: &schema.ProductFilter{
+			VendorName: strPtr("ibm"),
+			Region:     strPtr(r.Location),
+			Service:    &r.Service,
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "planName", Value: &r.Plan},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			Unit: strPtr(documents_unit_name),
+		},
+	}
 }
 
 /*
@@ -102,6 +141,8 @@ func WDMonthlyDocumentsCostComponent(r *ResourceInstance) *schema.CostComponent 
 func WDMonthlyQueriesCostComponent(r *ResourceInstance) *schema.CostComponent {
 	var quantity *decimal.Decimal
 
+	// TODO: Determine quantity
+	// Unit name: "GRADUATED_PRICE_QUERIES_PER_MONTH"
 }
 
 /*
@@ -111,6 +152,7 @@ func WDMonthlyQueriesCostComponent(r *ResourceInstance) *schema.CostComponent {
 func WDMonthlyCustomModelsCostComponent(r *ResourceInstance) *schema.CostComponent {
 	var quantity *decimal.Decimal
 
+	// Unit name: "CUSTOM_MODELS_PER_MONTH"
 }
 
 /*
@@ -120,4 +162,5 @@ func WDMonthlyCustomModelsCostComponent(r *ResourceInstance) *schema.CostCompone
 func WDMonthlyCollectionsCostComponent(r *ResourceInstance) *schema.CostComponent {
 	var quantity *decimal.Decimal
 
+	// Unit name: "ENTERPRISE_COLLECTIONS_TOTAL"
 }

--- a/internal/resources/ibm/resource_instance_discovery.go
+++ b/internal/resources/ibm/resource_instance_discovery.go
@@ -1,0 +1,123 @@
+package ibm
+
+import (
+	"fmt"
+
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+var ENTERPRISE_PLAN_PROGRAMMATIC_NAME string = "enterprise"
+var PLUS_PLAN_PROGRAMMATIC_NAME string = "plus"
+
+/*
+ * Plus = 'plus'
+ * Enterprise = 'enterprise'
+ * Premium = 'premium' (not applicable, need to call for pricing)
+ */
+func GetWDCostComponents(r *ResourceInstance) []*schema.CostComponent {
+	if r.Plan == PLUS_PLAN_PROGRAMMATIC_NAME {
+		return []*schema.CostComponent{
+			WDInstanceCostComponent(r),
+			WDMonthlyDocumentsCostComponent(r),
+			WDMonthlyQueriesCostComponent(r),
+		}
+	} else if r.Plan == ENTERPRISE_PLAN_PROGRAMMATIC_NAME {
+		return []*schema.CostComponent{
+			WDInstanceCostComponent(r),
+			WDMonthlyDocumentsCostComponent(r),
+			WDMonthlyQueriesCostComponent(r),
+			WDMonthlyCustomModelsCostComponent(r),
+			WDMonthlyCollectionsCostComponent(r),
+		}
+	} else {
+		costComponent := schema.CostComponent{
+			Name:            fmt.Sprintf("Plan %s with customized pricing", r.Plan),
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+		}
+		costComponent.SetCustomPrice(decimalPtr(decimal.NewFromInt(0)))
+		return []*schema.CostComponent{
+			&costComponent,
+		}
+	}
+}
+
+/*
+ * Instance
+ * - Plus: $USD/instance/month
+ * - Enterprise: $USD/instance/month
+ */
+func WDInstanceCostComponent(r *ResourceInstance) *schema.CostComponent {
+
+	var quantity *decimal.Decimal
+	var instances_unit_name string
+
+	if r.WD_Instance != nil {
+		quantity = decimalPtr(decimal.NewFromFloat(*r.WD_Instance))
+	} else {
+		quantity = decimalPtr(decimal.NewFromInt(1))
+	}
+
+	if r.Plan == PLUS_PLAN_PROGRAMMATIC_NAME {
+		instances_unit_name = "PLUS_SERVICE_INSTANCES_PER_MONTH"
+	} else {
+		instances_unit_name = "ENTERPRISE_SERVICE_INSTANCES_PER_MONTH"
+	}
+
+	return &schema.CostComponent{
+		Name:            "Instance",
+		Unit:            "Instance",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: quantity,
+		ProductFilter: &schema.ProductFilter{
+			VendorName: strPtr("ibm"),
+			Region:     strPtr(r.Location),
+			Service:    &r.Service,
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "planName", Value: &r.Plan},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			Unit: strPtr(instances_unit_name),
+		},
+	}
+}
+
+/*
+ * Documents:
+ * - Plus: $USD/documents/month. Includes 10,000 documents per month; $USD for every additional 1,000 documents.
+ * - Enterprise: $USD/documents/month. Includes 100,000 documents per month; $USD for every additional 1,000 documents.
+ */
+func WDMonthlyDocumentsCostComponent(r *ResourceInstance) *schema.CostComponent {
+	var quantity *decimal.Decimal
+
+}
+
+/*
+ * Queries:
+ * - Plus: $USD/queries/month. Includes 10,000 queries per month; $USD for every additional 1,000 queries.
+ * - Enterprise: $USD/queries/month. Includes 100,000 queries per month; $USD for every additional 1,000 queries.
+ */
+func WDMonthlyQueriesCostComponent(r *ResourceInstance) *schema.CostComponent {
+	var quantity *decimal.Decimal
+
+}
+
+/*
+ * Custom Models:
+ * - Enterprise: $USD/additional custom models/month. Includes 3 custom models per month.
+ */
+func WDMonthlyCustomModelsCostComponent(r *ResourceInstance) *schema.CostComponent {
+	var quantity *decimal.Decimal
+
+}
+
+/*
+ * Collections
+ * - Enterprise: $USD/additional collections/month. Includes 300 collections per month; $USD for every additional 100 collections.
+ */
+func WDMonthlyCollectionsCostComponent(r *ResourceInstance) *schema.CostComponent {
+	var quantity *decimal.Decimal
+
+}


### PR DESCRIPTION
Programmatic name under IBM resource `resource_instance`: `discovery`

Plans:
- Plus
- Enterprise