### PR TITLE
add planname to logdna cost component

### DIFF
--- a/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.golden
+++ b/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.golden
@@ -37,11 +37,20 @@
  ├─ Key versions free allowance (first 5 Key Versions)                                       5  Key Versions                           $0.00 
  └─ Key versions                                                                           295  Key Versions                         $317.52 
                                                                                                                                              
+ ibm_resource_instance.resource_instance_logdna_14day                                                                                        
+ └─ Gigabyte Months (14-day)                                                                 1  Gigabyte Months                        $2.15 
+                                                                                                                                             
+ ibm_resource_instance.resource_instance_logdna_30day                                                                                        
+ └─ Gigabyte Months (30-day)                                                                 1  Gigabyte Months                        $3.23 
+                                                                                                                                             
  ibm_resource_instance.resource_instance_logdna_7day                                                                                         
- └─ Gigabyte Months                                                                         10  Gigabyte Months                       $15.00 
+ └─ Gigabyte Months (7-day)                                                                  1  Gigabyte Months                        $1.50 
                                                                                                                                              
  ibm_resource_instance.resource_instance_logdna_7day_no_usage                                                                                
- └─ Gigabyte Months                                                      Monthly cost depends on usage: $1.50 per Gigabyte Months            
+ └─ Gigabyte Months (7-day)                                              Monthly cost depends on usage: $1.50 per Gigabyte Months            
+                                                                                                                                             
+ ibm_resource_instance.resource_instance_logdna_hipaa30day                                                                                   
+ └─ Gigabyte Months (hipaa-30-day)                                                           1  Gigabyte Months                        $4.12 
                                                                                                                                              
  ibm_resource_instance.resource_instance_logdna_lite                                                                                         
  └─ Lite plan                                                                                1                                         $0.00 
@@ -130,7 +139,7 @@
  ├─ Class 2 Resource Units                                                                  50  RU                                     $0.09 
  └─ Class 3 Resource Units                                                                  50  RU                                     $0.25 
                                                                                                                                              
- OVERALL TOTAL                                                                                                                    $15,474.55 
+ OVERALL TOTAL                                                                                                                    $15,470.56 
 ──────────────────────────────────
-29 cloud resources were detected:
-∙ 29 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+32 cloud resources were detected:
+∙ 32 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.tf
+++ b/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.tf
@@ -63,6 +63,26 @@ resource "ibm_resource_instance" "resource_instance_logdna_7day_no_usage" {
   plan              = "7-day"
   location          = "us-south"
 }
+resource "ibm_resource_instance" "resource_instance_logdna_14day" {
+  name              = "logdna-14day"
+  service           = "logdna"
+  plan              = "14-day"
+  location          = "us-south"
+}
+
+resource "ibm_resource_instance" "resource_instance_logdna_30day" {
+  name              = "logdna-30day"
+  service           = "logdna"
+  plan              = "30-day"
+  location          = "us-south"
+}
+
+resource "ibm_resource_instance" "resource_instance_logdna_hipaa30day" {
+  name              = "logdna-hipaa30day"
+  service           = "logdna"
+  plan              = "hipaa-30-day"
+  location          = "us-south"
+}
 
 resource "ibm_resource_instance" "resource_instance_activity_tracker_lite" {
   name              = "activity-tracker-lite"

--- a/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.usage.yml
+++ b/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.usage.yml
@@ -10,9 +10,15 @@ resource_usage:
     appid_users: 1000
     appid_advanced_authentications: 20000
   ibm_resource_instance.resource_instance_logdna_7day:
-    logdna_gigabyte_months: 10
+    logdna_gigabyte_months: 1
   ibm_resource_instance.resource_instance_logdna_lite:
-    logdna_gigabyte_months: 10
+    logdna_gigabyte_months: 11
+  ibm_resource_instance.resource_instance_logdna_14day:
+    logdna_gigabyte_months: 1
+  ibm_resource_instance.resource_instance_logdna_30day:
+    logdna_gigabyte_months: 1
+  ibm_resource_instance.resource_instance_logdna_hipaa30day:
+    logdna_gigabyte_months: 1
   ibm_resource_instance.resource_instance_activity_tracker_7day:
     activitytracker_gigabyte_months: 10
   ibm_resource_instance.resource_instance_activity_tracker_lite:

--- a/internal/resources/ibm/resource_instance.go
+++ b/internal/resources/ibm/resource_instance.go
@@ -501,7 +501,7 @@ func GetLogDNACostComponents(r *ResourceInstance) []*schema.CostComponent {
 		}
 	} else {
 		return []*schema.CostComponent{{
-			Name:            "Gigabyte Months",
+			Name:            fmt.Sprintf("Gigabyte Months (%s)", r.Plan),
 			Unit:            "Gigabyte Months",
 			UnitMultiplier:  decimal.NewFromInt(1),
 			MonthlyQuantity: q,


### PR DESCRIPTION
> estimates not showing for logdna because a default quantity was not set for that type of resource. This has been updated to 1 gb/month so the estimates will now show a cost for each gb months.
> an improvement has been made to the name of the cost component to include the plan type.