### PR TITLE
Add support for Secrets Manager Event Notifications registration

### DIFF
--- a/internal/providers/terraform/ibm/registry.go
+++ b/internal/providers/terraform/ibm/registry.go
@@ -156,6 +156,7 @@ var FreeResources = []string{
 	"ibm_scc_template",
 	"ibm_scc_template_attachment",
 	"ibm_sm_arbitrary_secret",
+	"ibm_sm_en_registration",
 	"ibm_sm_iam_credentials_configuration",
 	"ibm_sm_imported_certificate",
 	"ibm_sm_private_certificate",


### PR DESCRIPTION
### Added

- Support for free resource `ibm_sm_en_registration`.
> Note: Originally included as part of pending Event Notifications support; however, we'll add it now instead to fast track it.