### PR TITLE
Add support for Cloudant DB

### DIFF
--- a/internal/providers/terraform/ibm/registry.go
+++ b/internal/providers/terraform/ibm/registry.go
@@ -79,6 +79,7 @@ var FreeResources = []string{
 	"ibm_cd_toolchain_tool_slack",
 	"ibm_cd_toolchain_tool_sonarqube",
 	"ibm_cloud_shell_account_settings",
+	"ibm_cloudant_database",
 	"ibm_container_addons",
 	"ibm_cos_bucket_object_lock_configuration",
 	"ibm_dns_custom_resolver",


### PR DESCRIPTION
## Added

- Support for Cloudant database. Note that Infracost already supports the Cloudant service with resource `ibm_cloudant`.