### PR TITLE
Add support for Event Streams resources

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -94,6 +94,17 @@ resource_type_default_usage:
     dns-svcs_qty_custom_resolver_locations: 1 # Number of resolver locations
     dns-svcs_qty_glb_instances: 1 # Number of GLBs
     dns-svcs_qty_pools: 1 # Number of pools
+    messagehub_CAPACITY_UNIT_HOURS: 1
+    messagehub_qty_capacity_units: 1
+    messagehub_CAPACITY_UNIT_HOURS_ADDITIONAL: 1
+    messagehub_qty_capacity_units_additional: 1 
+    messagehub_CAPACITY_UNIT_HOURS_MIRRORING: 1
+    messagehub_qty_capacity_units_mirroring: 1
+    messagehub_INSTANCE_HOURS: 1
+    messagehub_qty_instances: 1
+    messagehub_TERABYTE_HOURS: 1
+    messagehub_qty_terabytes: 1
+    messagehub_GIGABYTE_TRANSMITTED_OUTBOUNDS: 1
 
   ibm_tg_gateway: 
     connection: 3
@@ -1372,6 +1383,20 @@ resource_usage:
     dns-svcs_qty_custom_resolver_locations: 1 # Number of resolver locations
     dns-svcs_qty_glb_instances: 1 # Number of GLBs
     dns-svcs_qty_pools: 1 # Number of pools
+  
+  ibm_resource_instance.event_streams:
+    messagehub_CAPACITY_UNIT_HOURS: 1
+    messagehub_qty_capacity_units: 1
+    messagehub_CAPACITY_UNIT_HOURS_ADDITIONAL: 1
+    messagehub_qty_capacity_units_additional: 1
+    messagehub_CAPACITY_UNIT_HOURS_MIRRORING: 1
+    messagehub_qty_capacity_units_mirroring: 1
+    messagehub_INSTANCE_HOURS: 1
+    messagehub_qty_instances: 1
+    messagehub_TERABYTE_HOURS: 1
+    messagehub_qty_terabytes: 1
+    messagehub_GIGABYTE_TRANSMITTED_OUTBOUNDS: 1
+
 
   ibm_tg_gateway.tg_gateway:
     connection: 25 # Monthly number of connections to the gateway

--- a/internal/providers/terraform/ibm/ibm.go
+++ b/internal/providers/terraform/ibm/ibm.go
@@ -87,6 +87,7 @@ var globalCatalogServiceId = map[string]catalogMetadata{
 	"continuous-delivery":           {"59b735ee-5938-4ebd-a6b2-541aef2d1f68", []string{}, nil, "https://cloud.ibm.com/catalog/services/continuous-delivery"},
 	"compliance":                    {"compliance", []string{}, nil, "https://cloud.ibm.com/catalog/services/security-and-compliance-center"},
 	"dns-svcs":                      {"b4ed8a30-936f-11e9-b289-1d079699cbe5", []string{}, nil, "https://cloud.ibm.com/catalog/services/dns-services"},
+	"messagehub":                    {"6a7f4e38-f218-48ef-9dd2-df408747568e", []string{}, nil, "https://cloud.ibm.com/eventstreams-provisioning/6a7f4e38-f218-48ef-9dd2-df408747568e/create"},
 }
 
 func SetCatalogMetadata(d *schema.ResourceData, resourceType string, config map[string]any) {

--- a/internal/providers/terraform/ibm/registry.go
+++ b/internal/providers/terraform/ibm/registry.go
@@ -83,6 +83,8 @@ var FreeResources = []string{
 	"ibm_container_addons",
 	"ibm_cos_bucket_object_lock_configuration",
 	"ibm_dns_custom_resolver",
+	"ibm_event_streams_schema",
+	"ibm_event_streams_topic",
 	"ibm_iam_access_group",
 	"ibm_iam_access_group_account_settings",
 	"ibm_iam_access_group_dynamic_rule",

--- a/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.golden
+++ b/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.golden
@@ -18,6 +18,24 @@
  └─ Additional Million DNS Queries (first 999 Million Queries)                             999  Million Queries                      $645.16 
  └─ Additional Million DNS Queries (over 999 Million Queries)                                1  Million Queries                        $0.32 
                                                                                                                                              
+ ibm_resource_instance.messagehub_enterprise                                                                                                 
+ ├─ Base Capacity Unit-Hour                                                                  1  Hours                                  $7.37 
+ ├─ Additional Capacity Unit-Hour                                                            1  Hours                                  $7.37 
+ ├─ Additional Storage Terabyte per Hour                                                    10  Hours                                  $6.46 
+ ├─ Gigabyte Transmitted Outbound                                                          100  GB                                     $8.61 
+ └─ Mirroring Capacity Unit-Hour                                                             1  Hours                                  $1.47 
+                                                                                                                                             
+ ibm_resource_instance.messagehub_lite                                                                                                       
+ └─ Lite plan                                                                                1                                         $0.00 
+                                                                                                                                             
+ ibm_resource_instance.messagehub_satellite                                                                                                  
+ ├─ Base Capacity Unit-Hour                                                                  1  Hours                                  $7.37 
+ └─ Additional Capacity Unit-Hour                                                            1  Hours                                  $7.37 
+                                                                                                                                             
+ ibm_resource_instance.messagehub_standard                                                                                                   
+ ├─ Partition Hours                                                                        100  Hours                                  $1.50 
+ └─ Gigabyte Transmitted Outbound                                                          100  GB                                     $8.61 
+                                                                                                                                             
  ibm_resource_instance.resource_instance_activity_tracker_7day                                                                               
  └─ Gigabyte Months                                                                         10  Gigabyte Months                       $16.15 
                                                                                                                                              
@@ -179,7 +197,7 @@
  ├─ Class 2 Resource Units                                                                  50  RU                                     $0.09 
  └─ Class 3 Resource Units                                                                  50  RU                                     $0.25 
                                                                                                                                              
- OVERALL TOTAL                                                                                                                    $19,248.98 
+ OVERALL TOTAL                                                                                                                    $19,305.11 
 ──────────────────────────────────
-37 cloud resources were detected:
-∙ 37 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+41 cloud resources were detected:
+∙ 41 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.tf
+++ b/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ibm = {
       source = "IBM-Cloud/ibm"
-      version = "1.63.0"
+      version = "1.64.0"
     }
   }
 }
@@ -295,5 +295,37 @@ resource "ibm_resource_instance" "dns_svcs_standard" {
   service           = "dns-svcs"
   plan              = "standard-dns"
   location          = "global"
+  resource_group_id = "default"
+}
+
+resource "ibm_resource_instance" "messagehub_lite" {
+  name              = "messagehub_lite"
+  service           = "messagehub"
+  plan              = "lite"
+  location          = "us-south"
+  resource_group_id = "default"
+}
+
+resource "ibm_resource_instance" "messagehub_standard" {
+  name              = "messagehub_standard"
+  service           = "messagehub"
+  plan              = "standard"
+  location          = "us-south"
+  resource_group_id = "default"
+}
+
+resource "ibm_resource_instance" "messagehub_enterprise" {
+  name              = "messagehub_enterprise"
+  service           = "messagehub"
+  plan              = "enterprise-3nodes-2tb"
+  location          = "us-south"
+  resource_group_id = "default"
+}
+
+resource "ibm_resource_instance" "messagehub_satellite" {
+  name              = "messagehub_satellite"
+  service           = "messagehub"
+  plan              = "satellite"
+  location          = "satcon_dal"
   resource_group_id = "default"
 }

--- a/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.usage.yml
+++ b/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.usage.yml
@@ -109,3 +109,38 @@ resource_usage:
     dns-svcs_qty_custom_resolver_locations: 1 # Number of resolver locations
     dns-svcs_qty_glb_instances: 1 # Number of GLBs
     dns-svcs_qty_pools: 1 # Number of pools
+
+  ibm_resource_instance.messagehub_lite:
+    messagehub_CAPACITY_UNIT_HOURS: 1
+    messagehub_qty_capacity_units: 1
+    messagehub_CAPACITY_UNIT_HOURS_ADDITIONAL: 1
+    messagehub_qty_capacity_units_additional: 1 
+    messagehub_CAPACITY_UNIT_HOURS_MIRRORING: 1
+    messagehub_qty_capacity_units_mirroring: 1
+    messagehub_INSTANCE_HOURS: 1
+    messagehub_qty_instances: 1
+    messagehub_TERABYTE_HOURS: 1
+    messagehub_qty_terabytes: 1
+    messagehub_GIGABYTE_TRANSMITTED_OUTBOUNDS: 1
+
+  ibm_resource_instance.messagehub_standard:
+    messagehub_INSTANCE_HOURS: 100
+    messagehub_qty_instances: 1
+    messagehub_GIGABYTE_TRANSMITTED_OUTBOUNDS: 100
+    
+  ibm_resource_instance.messagehub_enterprise:
+    messagehub_CAPACITY_UNIT_HOURS: 1
+    messagehub_qty_capacity_units: 1
+    messagehub_CAPACITY_UNIT_HOURS_ADDITIONAL: 1
+    messagehub_qty_capacity_units_additional: 1 
+    messagehub_CAPACITY_UNIT_HOURS_MIRRORING: 1
+    messagehub_qty_capacity_units_mirroring: 1
+    messagehub_TERABYTE_HOURS: 10
+    messagehub_qty_terabytes: 1
+    messagehub_GIGABYTE_TRANSMITTED_OUTBOUNDS: 100
+
+  ibm_resource_instance.messagehub_satellite:
+    messagehub_CAPACITY_UNIT_HOURS: 1
+    messagehub_qty_capacity_units: 1
+    messagehub_CAPACITY_UNIT_HOURS_ADDITIONAL: 1
+    messagehub_qty_capacity_units_additional: 1 

--- a/internal/resources/ibm/resource_instance.go
+++ b/internal/resources/ibm/resource_instance.go
@@ -96,6 +96,18 @@ type ResourceInstance struct {
 	DNSServices_PoolHours                     *float64 `infracost_usage:"dns-svcs_NUMBERPOOLS"`
 	DNSServices_Pools                         *int64   `infracost_usage:"dns-svcs_qty_pools"`
 	DNSServices_Zones                         *int64   `infracost_usage:"dns-svcs_ITEMS"`
+	// Event Streams
+	EventStreams_CapacityUnitHours            *float64 `infracost_usage:"messagehub_CAPACITY_UNIT_HOURS"`
+	EventStreams_CapacityUnitHoursAdditional  *float64 `infracost_usage:"messagehub_CAPACITY_UNIT_HOURS_ADDITIONAL"`
+	EventStreams_CapacityUnitHoursMirroring   *float64 `infracost_usage:"messagehub_CAPACITY_UNIT_HOURS_MIRRORING"`
+	EventStreams_CapacityUnits                *float64 `infracost_usage:"messagehub_qty_capacity_units"`
+	EventStreams_CapacityUnitsAdditional      *float64 `infracost_usage:"messagehub_qty_capacity_units_additional"`
+	EventStreams_CapacityUnitsMirroring       *float64 `infracost_usage:"messagehub_qty_capacity_units_mirroring"`
+	EventStreams_GigabyteTransmittedOutbounds *float64 `infracost_usage:"messagehub_GIGABYTE_TRANSMITTED_OUTBOUNDS"`
+	EventStreams_InstanceHours                *float64 `infracost_usage:"messagehub_INSTANCE_HOURS"`
+	EventStreams_Instances                    *float64 `infracost_usage:"messagehub_qty_instances"`
+	EventStreams_TerabyteHours                *float64 `infracost_usage:"messagehub_TERABYTE_HOURS"`
+	EventStreams_Terabytes                    *float64 `infracost_usage:"messagehub_qty_terabytes"`
 }
 
 type ResourceCostComponentsFunc func(*ResourceInstance) []*schema.CostComponent
@@ -154,6 +166,17 @@ var ResourceInstanceUsageSchema = []*schema.UsageItem{
 	{Key: "dns-svcs_qty_custom_resolver_locations", DefaultValue: 1, ValueType: schema.Int64},
 	{Key: "dns-svcs_qty_glb_instances", DefaultValue: 1, ValueType: schema.Int64},
 	{Key: "dns-svcs_qty_pools", DefaultValue: 1, ValueType: schema.Int64},
+	{Key: "messagehub_CAPACITY_UNIT_HOURS", DefaultValue: 1, ValueType: schema.Float64},
+	{Key: "messagehub_CAPACITY_UNIT_HOURS_ADDITIONAL", DefaultValue: 1, ValueType: schema.Float64},
+	{Key: "messagehub_CAPACITY_UNIT_HOURS_MIRRORING", DefaultValue: 1, ValueType: schema.Float64},
+	{Key: "messagehub_qty_capacity_units", DefaultValue: 1, ValueType: schema.Float64},
+	{Key: "messagehub_qty_capacity_units_additional", DefaultValue: 1, ValueType: schema.Float64},
+	{Key: "messagehub_qty_capacity_units_mirroring", DefaultValue: 1, ValueType: schema.Float64},
+	{Key: "messagehub_GIGABYTE_TRANSMITTED_OUTBOUNDS", DefaultValue: 1, ValueType: schema.Float64},
+	{Key: "messagehub_INSTANCE_HOURS", DefaultValue: 1, ValueType: schema.Float64},
+	{Key: "messagehub_qty_instances", DefaultValue: 1, ValueType: schema.Float64},
+	{Key: "messagehub_TERABYTE_HOURS", DefaultValue: 1, ValueType: schema.Float64},
+	{Key: "messagehub_qty_terabytes", DefaultValue: 1, ValueType: schema.Float64},
 }
 
 var ResourceInstanceCostMap map[string]ResourceCostComponentsFunc = map[string]ResourceCostComponentsFunc{
@@ -174,6 +197,7 @@ var ResourceInstanceCostMap map[string]ResourceCostComponentsFunc = map[string]R
 	"sysdig-secure":           GetSCCWPCostComponents,
 	"aiopenscale":             GetWGOVCostComponents,
 	"dns-svcs":                GetDNSServicesCostComponents,
+	"messagehub":              GetEventStreamsCostComponents,
 }
 
 func KMSKeyVersionsFreeCostComponent(r *ResourceInstance) *schema.CostComponent {

--- a/internal/resources/ibm/resource_instance_messagehub.go
+++ b/internal/resources/ibm/resource_instance_messagehub.go
@@ -1,0 +1,224 @@
+package ibm
+
+import (
+	"fmt"
+
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+const EVENT_STREAMS_PROGRAMMATIC_ENTERPRISE_PLAN_NAME string = "enterprise-3nodes-2tb"
+const EVENT_STREAMS_PROGRAMMATIC_LITE_PLAN_NAME string = "lite" // only available in us-south
+const EVENT_STREAMS_PROGRAMMATIC_SATELLITE_PLAN_NAME string = "satellite"
+const EVENT_STREAMS_PROGRAMMATIC_STANDARD_PLAN_NAME string = "standard"
+
+func GetEventStreamsCostComponents(r *ResourceInstance) []*schema.CostComponent {
+
+	if r.Plan == EVENT_STREAMS_PROGRAMMATIC_ENTERPRISE_PLAN_NAME {
+		return []*schema.CostComponent{
+			EventStreamsCapacityUnitHoursCostComponent(r),
+			EventStreamsCapacityUnitHoursAdditionalCostComponent(r),
+			EventStreamsTerabyteHoursCostComponent(r),
+			EventStreamsGBTransmittedOutboundsCostComponent(r),
+			EventStreamsCapacityUnitHoursMirroringCostComponent(r),
+		}
+	} else if r.Plan == EVENT_STREAMS_PROGRAMMATIC_SATELLITE_PLAN_NAME {
+		return []*schema.CostComponent{
+			EventStreamsCapacityUnitHoursCostComponent(r),
+			EventStreamsCapacityUnitHoursAdditionalCostComponent(r),
+		}
+	} else if r.Plan == EVENT_STREAMS_PROGRAMMATIC_STANDARD_PLAN_NAME {
+		return []*schema.CostComponent{
+			EventStreamsInstanceHoursCostComponent(r),
+			EventStreamsGBTransmittedOutboundsCostComponent(r),
+		}
+	} else if r.Plan == EVENT_STREAMS_PROGRAMMATIC_LITE_PLAN_NAME {
+		costComponent := &schema.CostComponent{
+			Name:            "Lite plan",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+		}
+		costComponent.SetCustomPrice(decimalPtr(decimal.NewFromInt(0)))
+		return []*schema.CostComponent{costComponent}
+	} else {
+		costComponent := schema.CostComponent{
+			Name:            fmt.Sprintf("Plan %s with customized pricing", r.Plan),
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+		}
+		costComponent.SetCustomPrice(decimalPtr(decimal.NewFromInt(0)))
+		return []*schema.CostComponent{
+			&costComponent,
+		}
+	}
+
+}
+
+// Charged by Standard plan only
+func EventStreamsInstanceHoursCostComponent(r *ResourceInstance) *schema.CostComponent {
+
+	// var quantity *decimal.Decimal
+
+	// if r.<VAR> != nil {
+	// 	quantity = ???
+	// }
+
+	// costComponent := schema.CostComponent{
+	// 	Name:            "",
+	// 	Unit:            "",
+	// 	UnitMultiplier:  decimal.NewFromFloat(1), // Final quantity for this cost component will be divided by this amount
+	// 	MonthlyQuantity: quantity,
+	// 	ProductFilter: &schema.ProductFilter{
+	// 		VendorName: strPtr("ibm"),
+	// 		Region:     strPtr(r.Location),
+	// 		Service:    &r.Service,
+	// 		AttributeFilters: []*schema.AttributeFilter{
+	// 			{Key: "planName", Value: &r.Plan},
+	// 		},
+	// 	},
+	// 	PriceFilter: &schema.PriceFilter{
+	// 		Unit: strPtr("INSTANCE_HOURS"),
+	// 	},
+	// }
+	// return &costComponent
+}
+
+func EventStreamsGBTransmittedOutboundsCostComponent(r *ResourceInstance) *schema.CostComponent {
+
+	// var quantity *decimal.Decimal
+
+	// if r.<VAR> != nil {
+	// 	quantity = ???
+	// }
+
+	// costComponent := schema.CostComponent{
+	// 	Name:            "",
+	// 	Unit:            "",
+	// 	UnitMultiplier:  decimal.NewFromFloat(1), // Final quantity for this cost component will be divided by this amount
+	// 	MonthlyQuantity: quantity,
+	// 	ProductFilter: &schema.ProductFilter{
+	// 		VendorName: strPtr("ibm"),
+	// 		Region:     strPtr(r.Location),
+	// 		Service:    &r.Service,
+	// 		AttributeFilters: []*schema.AttributeFilter{
+	// 			{Key: "planName", Value: &r.Plan},
+	// 		},
+	// 	},
+	// 	PriceFilter: &schema.PriceFilter{
+	// 		Unit: strPtr("GIGABYTE_TRANSMITTED_OUTBOUNDS"),
+	// 	},
+	// }
+	// return &costComponent
+}
+
+func EventStreamsCapacityUnitHoursCostComponent(r *ResourceInstance) *schema.CostComponent {
+
+	// var quantity *decimal.Decimal
+
+	// if r.<VAR> != nil {
+	// 	quantity = ???
+	// }
+
+	// costComponent := schema.CostComponent{
+	// 	Name:            "",
+	// 	Unit:            "",
+	// 	UnitMultiplier:  decimal.NewFromFloat(1), // Final quantity for this cost component will be divided by this amount
+	// 	MonthlyQuantity: quantity,
+	// 	ProductFilter: &schema.ProductFilter{
+	// 		VendorName: strPtr("ibm"),
+	// 		Region:     strPtr(r.Location),
+	// 		Service:    &r.Service,
+	// 		AttributeFilters: []*schema.AttributeFilter{
+	// 			{Key: "planName", Value: &r.Plan},
+	// 		},
+	// 	},
+	// 	PriceFilter: &schema.PriceFilter{
+	// 		Unit: strPtr("CAPACITY_UNIT_HOURS"),
+	// 	},
+	// }
+	// return &costComponent
+}
+
+func EventStreamsCapacityUnitHoursAdditionalCostComponent(r *ResourceInstance) *schema.CostComponent {
+
+	// var quantity *decimal.Decimal
+
+	// if r.<VAR> != nil {
+	// 	quantity = ???
+	// }
+
+	// costComponent := schema.CostComponent{
+	// 	Name:            "",
+	// 	Unit:            "",
+	// 	UnitMultiplier:  decimal.NewFromFloat(1), // Final quantity for this cost component will be divided by this amount
+	// 	MonthlyQuantity: quantity,
+	// 	ProductFilter: &schema.ProductFilter{
+	// 		VendorName: strPtr("ibm"),
+	// 		Region:     strPtr(r.Location),
+	// 		Service:    &r.Service,
+	// 		AttributeFilters: []*schema.AttributeFilter{
+	// 			{Key: "planName", Value: &r.Plan},
+	// 		},
+	// 	},
+	// 	PriceFilter: &schema.PriceFilter{
+	// 		Unit: strPtr("CAPACITY_UNIT_HOURS_ADDITIONAL"),
+	// 	},
+	// }
+	// return &costComponent
+}
+
+func EventStreamsTerabyteHoursCostComponent(r *ResourceInstance) *schema.CostComponent {
+
+	// var quantity *decimal.Decimal
+
+	// if r.<VAR> != nil {
+	// 	quantity = ???
+	// }
+
+	// costComponent := schema.CostComponent{
+	// 	Name:            "",
+	// 	Unit:            "",
+	// 	UnitMultiplier:  decimal.NewFromFloat(1), // Final quantity for this cost component will be divided by this amount
+	// 	MonthlyQuantity: quantity,
+	// 	ProductFilter: &schema.ProductFilter{
+	// 		VendorName: strPtr("ibm"),
+	// 		Region:     strPtr(r.Location),
+	// 		Service:    &r.Service,
+	// 		AttributeFilters: []*schema.AttributeFilter{
+	// 			{Key: "planName", Value: &r.Plan},
+	// 		},
+	// 	},
+	// 	PriceFilter: &schema.PriceFilter{
+	// 		Unit: strPtr("TERABYTE_HOURS"),
+	// 	},
+	// }
+	// return &costComponent
+}
+
+func EventStreamsCapacityUnitHoursMirroringCostComponent(r *ResourceInstance) *schema.CostComponent {
+
+	// var quantity *decimal.Decimal
+
+	// if r.<VAR> != nil {
+	// 	quantity = ???
+	// }
+
+	// costComponent := schema.CostComponent{
+	// 	Name:            "",
+	// 	Unit:            "",
+	// 	UnitMultiplier:  decimal.NewFromFloat(1), // Final quantity for this cost component will be divided by this amount
+	// 	MonthlyQuantity: quantity,
+	// 	ProductFilter: &schema.ProductFilter{
+	// 		VendorName: strPtr("ibm"),
+	// 		Region:     strPtr(r.Location),
+	// 		Service:    &r.Service,
+	// 		AttributeFilters: []*schema.AttributeFilter{
+	// 			{Key: "planName", Value: &r.Plan},
+	// 		},
+	// 	},
+	// 	PriceFilter: &schema.PriceFilter{
+	// 		Unit: strPtr("CAPACITY_UNIT_HOURS_MIRRORING"),
+	// 	},
+	// }
+	// return &costComponent
+}

--- a/internal/resources/ibm/resource_instance_messagehub.go
+++ b/internal/resources/ibm/resource_instance_messagehub.go
@@ -57,168 +57,168 @@ func GetEventStreamsCostComponents(r *ResourceInstance) []*schema.CostComponent 
 // Charged by Standard plan only
 func EventStreamsInstanceHoursCostComponent(r *ResourceInstance) *schema.CostComponent {
 
-	// var quantity *decimal.Decimal
+	var quantity *decimal.Decimal
 
-	// if r.<VAR> != nil {
-	// 	quantity = ???
-	// }
+	if (r.EventStreams_Instances) != nil && (r.EventStreams_InstanceHours != nil) {
+		quantity = decimalPtr(decimal.NewFromFloat(*r.EventStreams_Instances * *r.EventStreams_InstanceHours))
+	}
 
-	// costComponent := schema.CostComponent{
-	// 	Name:            "",
-	// 	Unit:            "",
-	// 	UnitMultiplier:  decimal.NewFromFloat(1), // Final quantity for this cost component will be divided by this amount
-	// 	MonthlyQuantity: quantity,
-	// 	ProductFilter: &schema.ProductFilter{
-	// 		VendorName: strPtr("ibm"),
-	// 		Region:     strPtr(r.Location),
-	// 		Service:    &r.Service,
-	// 		AttributeFilters: []*schema.AttributeFilter{
-	// 			{Key: "planName", Value: &r.Plan},
-	// 		},
-	// 	},
-	// 	PriceFilter: &schema.PriceFilter{
-	// 		Unit: strPtr("INSTANCE_HOURS"),
-	// 	},
-	// }
-	// return &costComponent
+	costComponent := schema.CostComponent{
+		Name:            "Partition Hours",
+		Unit:            "Hours",
+		UnitMultiplier:  decimal.NewFromFloat(1), // Final quantity for this cost component will be divided by this amount
+		MonthlyQuantity: quantity,
+		ProductFilter: &schema.ProductFilter{
+			VendorName: strPtr("ibm"),
+			Region:     strPtr(r.Location),
+			Service:    &r.Service,
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "planName", Value: &r.Plan},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			Unit: strPtr("INSTANCE_HOURS"), // Instance-Hour, Granular Tier
+		},
+	}
+	return &costComponent
 }
 
 func EventStreamsGBTransmittedOutboundsCostComponent(r *ResourceInstance) *schema.CostComponent {
 
-	// var quantity *decimal.Decimal
+	var quantity *decimal.Decimal
 
-	// if r.<VAR> != nil {
-	// 	quantity = ???
-	// }
+	if r.EventStreams_GigabyteTransmittedOutbounds != nil {
+		quantity = decimalPtr(decimal.NewFromFloat(*r.EventStreams_GigabyteTransmittedOutbounds))
+	}
 
-	// costComponent := schema.CostComponent{
-	// 	Name:            "",
-	// 	Unit:            "",
-	// 	UnitMultiplier:  decimal.NewFromFloat(1), // Final quantity for this cost component will be divided by this amount
-	// 	MonthlyQuantity: quantity,
-	// 	ProductFilter: &schema.ProductFilter{
-	// 		VendorName: strPtr("ibm"),
-	// 		Region:     strPtr(r.Location),
-	// 		Service:    &r.Service,
-	// 		AttributeFilters: []*schema.AttributeFilter{
-	// 			{Key: "planName", Value: &r.Plan},
-	// 		},
-	// 	},
-	// 	PriceFilter: &schema.PriceFilter{
-	// 		Unit: strPtr("GIGABYTE_TRANSMITTED_OUTBOUNDS"),
-	// 	},
-	// }
-	// return &costComponent
+	costComponent := schema.CostComponent{
+		Name:            "Gigabyte Transmitted Outbound",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromFloat(1), // Final quantity for this cost component will be divided by this amount
+		MonthlyQuantity: quantity,
+		ProductFilter: &schema.ProductFilter{
+			VendorName: strPtr("ibm"),
+			Region:     strPtr(r.Location),
+			Service:    &r.Service,
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "planName", Value: &r.Plan},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			Unit: strPtr("GIGABYTE_TRANSMITTED_OUTBOUNDS"), // Gigabyte Transmitted Outbound, Granular Tier
+		},
+	}
+	return &costComponent
 }
 
 func EventStreamsCapacityUnitHoursCostComponent(r *ResourceInstance) *schema.CostComponent {
 
-	// var quantity *decimal.Decimal
+	var quantity *decimal.Decimal
 
-	// if r.<VAR> != nil {
-	// 	quantity = ???
-	// }
+	if (r.EventStreams_CapacityUnits != nil) && (r.EventStreams_CapacityUnitHours != nil) {
+		quantity = decimalPtr(decimal.NewFromFloat(*r.EventStreams_CapacityUnits * *r.EventStreams_CapacityUnitHours))
+	}
 
-	// costComponent := schema.CostComponent{
-	// 	Name:            "",
-	// 	Unit:            "",
-	// 	UnitMultiplier:  decimal.NewFromFloat(1), // Final quantity for this cost component will be divided by this amount
-	// 	MonthlyQuantity: quantity,
-	// 	ProductFilter: &schema.ProductFilter{
-	// 		VendorName: strPtr("ibm"),
-	// 		Region:     strPtr(r.Location),
-	// 		Service:    &r.Service,
-	// 		AttributeFilters: []*schema.AttributeFilter{
-	// 			{Key: "planName", Value: &r.Plan},
-	// 		},
-	// 	},
-	// 	PriceFilter: &schema.PriceFilter{
-	// 		Unit: strPtr("CAPACITY_UNIT_HOURS"),
-	// 	},
-	// }
-	// return &costComponent
+	costComponent := schema.CostComponent{
+		Name:            "Base Capacity Unit-Hour",
+		Unit:            "Hours",
+		UnitMultiplier:  decimal.NewFromFloat(1), // Final quantity for this cost component will be divided by this amount
+		MonthlyQuantity: quantity,
+		ProductFilter: &schema.ProductFilter{
+			VendorName: strPtr("ibm"),
+			Region:     strPtr(r.Location),
+			Service:    &r.Service,
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "planName", Value: &r.Plan},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			Unit: strPtr("CAPACITY_UNIT_HOURS"), // Capacity Unit-Hour, Granular Tier
+		},
+	}
+	return &costComponent
 }
 
 func EventStreamsCapacityUnitHoursAdditionalCostComponent(r *ResourceInstance) *schema.CostComponent {
 
-	// var quantity *decimal.Decimal
+	var quantity *decimal.Decimal
 
-	// if r.<VAR> != nil {
-	// 	quantity = ???
-	// }
+	if (r.EventStreams_CapacityUnitsAdditional != nil) && (r.EventStreams_CapacityUnitHoursAdditional != nil) {
+		quantity = decimalPtr(decimal.NewFromFloat(*r.EventStreams_CapacityUnitsAdditional * *r.EventStreams_CapacityUnitHoursAdditional))
+	}
 
-	// costComponent := schema.CostComponent{
-	// 	Name:            "",
-	// 	Unit:            "",
-	// 	UnitMultiplier:  decimal.NewFromFloat(1), // Final quantity for this cost component will be divided by this amount
-	// 	MonthlyQuantity: quantity,
-	// 	ProductFilter: &schema.ProductFilter{
-	// 		VendorName: strPtr("ibm"),
-	// 		Region:     strPtr(r.Location),
-	// 		Service:    &r.Service,
-	// 		AttributeFilters: []*schema.AttributeFilter{
-	// 			{Key: "planName", Value: &r.Plan},
-	// 		},
-	// 	},
-	// 	PriceFilter: &schema.PriceFilter{
-	// 		Unit: strPtr("CAPACITY_UNIT_HOURS_ADDITIONAL"),
-	// 	},
-	// }
-	// return &costComponent
+	costComponent := schema.CostComponent{
+		Name:            "Additional Capacity Unit-Hour",
+		Unit:            "Hours",
+		UnitMultiplier:  decimal.NewFromFloat(1), // Final quantity for this cost component will be divided by this amount
+		MonthlyQuantity: quantity,
+		ProductFilter: &schema.ProductFilter{
+			VendorName: strPtr("ibm"),
+			Region:     strPtr(r.Location),
+			Service:    &r.Service,
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "planName", Value: &r.Plan},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			Unit: strPtr("CAPACITY_UNIT_HOURS_ADDITIONAL"), // Capacity Unit-Hour, Granular Tier
+		},
+	}
+	return &costComponent
 }
 
 func EventStreamsTerabyteHoursCostComponent(r *ResourceInstance) *schema.CostComponent {
 
-	// var quantity *decimal.Decimal
+	var quantity *decimal.Decimal
 
-	// if r.<VAR> != nil {
-	// 	quantity = ???
-	// }
+	if (r.EventStreams_Terabytes != nil) && (r.EventStreams_TerabyteHours != nil) {
+		quantity = decimalPtr(decimal.NewFromFloat(*r.EventStreams_Terabytes * *r.EventStreams_TerabyteHours))
+	}
 
-	// costComponent := schema.CostComponent{
-	// 	Name:            "",
-	// 	Unit:            "",
-	// 	UnitMultiplier:  decimal.NewFromFloat(1), // Final quantity for this cost component will be divided by this amount
-	// 	MonthlyQuantity: quantity,
-	// 	ProductFilter: &schema.ProductFilter{
-	// 		VendorName: strPtr("ibm"),
-	// 		Region:     strPtr(r.Location),
-	// 		Service:    &r.Service,
-	// 		AttributeFilters: []*schema.AttributeFilter{
-	// 			{Key: "planName", Value: &r.Plan},
-	// 		},
-	// 	},
-	// 	PriceFilter: &schema.PriceFilter{
-	// 		Unit: strPtr("TERABYTE_HOURS"),
-	// 	},
-	// }
-	// return &costComponent
+	costComponent := schema.CostComponent{
+		Name:            "Additional Storage Terabyte per Hour",
+		Unit:            "Hours",
+		UnitMultiplier:  decimal.NewFromFloat(1), // Final quantity for this cost component will be divided by this amount
+		MonthlyQuantity: quantity,
+		ProductFilter: &schema.ProductFilter{
+			VendorName: strPtr("ibm"),
+			Region:     strPtr(r.Location),
+			Service:    &r.Service,
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "planName", Value: &r.Plan},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			Unit: strPtr("TERABYTE_HOURS"), // Terabyte-Hour, Granular Tier
+		},
+	}
+	return &costComponent
 }
 
 func EventStreamsCapacityUnitHoursMirroringCostComponent(r *ResourceInstance) *schema.CostComponent {
 
-	// var quantity *decimal.Decimal
+	var quantity *decimal.Decimal
 
-	// if r.<VAR> != nil {
-	// 	quantity = ???
-	// }
+	if (r.EventStreams_CapacityUnitsMirroring != nil) && (r.EventStreams_CapacityUnitHoursMirroring != nil) {
+		quantity = decimalPtr(decimal.NewFromFloat(*r.EventStreams_CapacityUnitsMirroring * *r.EventStreams_CapacityUnitHoursMirroring))
+	}
 
-	// costComponent := schema.CostComponent{
-	// 	Name:            "",
-	// 	Unit:            "",
-	// 	UnitMultiplier:  decimal.NewFromFloat(1), // Final quantity for this cost component will be divided by this amount
-	// 	MonthlyQuantity: quantity,
-	// 	ProductFilter: &schema.ProductFilter{
-	// 		VendorName: strPtr("ibm"),
-	// 		Region:     strPtr(r.Location),
-	// 		Service:    &r.Service,
-	// 		AttributeFilters: []*schema.AttributeFilter{
-	// 			{Key: "planName", Value: &r.Plan},
-	// 		},
-	// 	},
-	// 	PriceFilter: &schema.PriceFilter{
-	// 		Unit: strPtr("CAPACITY_UNIT_HOURS_MIRRORING"),
-	// 	},
-	// }
-	// return &costComponent
+	costComponent := schema.CostComponent{
+		Name:            "Mirroring Capacity Unit-Hour",
+		Unit:            "Hours",
+		UnitMultiplier:  decimal.NewFromFloat(1), // Final quantity for this cost component will be divided by this amount
+		MonthlyQuantity: quantity,
+		ProductFilter: &schema.ProductFilter{
+			VendorName: strPtr("ibm"),
+			Region:     strPtr(r.Location),
+			Service:    &r.Service,
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "planName", Value: &r.Plan},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			Unit: strPtr("CAPACITY_UNIT_HOURS_MIRRORING"), // Capacity Unit-Hour, Granular Tier
+		},
+	}
+	return &costComponent
 }


### PR DESCRIPTION
## Added

- Support for service `messagehub`, under resource `ibm_resource_instace`.
- Support for resource `ibm_event_streams_schema` (free)
- Support for resource `ibm_event_streams_topic` (free)

## Testing

### Unit Testing

Results:

```
❯ go test -v ./internal/providers/terraform/ibm/resource_instance_test.go
=== RUN   TestResourceInstance
=== PAUSE TestResourceInstance
=== CONT  TestResourceInstance
=== RUN   TestResourceInstance/HCL
No IBM_CLOUD_IAM_URL credential set, defaults to production.
=== RUN   TestResourceInstance/Terraform_CLI
No IBM_CLOUD_IAM_URL credential set, defaults to production.
--- PASS: TestResourceInstance (26.24s)
    --- PASS: TestResourceInstance/HCL (1.66s)
    --- PASS: TestResourceInstance/Terraform_CLI (24.58s)
PASS
ok      command-line-arguments  27.355s
```

### Regression Testing

```
=============================== Coverage summary ===============================
Statements   : Unknown% ( 0/0 )
Branches     : Unknown% ( 0/0 )
Functions    : Unknown% ( 0/0 )
Lines        : Unknown% ( 0/0 )
================================================================================
Test Suites: 2 passed, 2 total
Tests:       11 passed, 11 total
Snapshots:   0 total
Time:        22.851 s
Ran all test suites matching /sanity*/i.
```