### PR TITLE
Add 'name' property of ibm_is_instance resource to catalog metadata

### DIFF
--- a/internal/providers/terraform/ibm/is_instance.go
+++ b/internal/providers/terraform/ibm/is_instance.go
@@ -23,6 +23,7 @@ func newIsInstance(d *schema.ResourceData, u *schema.UsageData) *schema.Resource
 	dedicatedHost := strings.TrimSpace(d.Get("dedicated_host").String())
 	dedicatedHostGroup := strings.TrimSpace(d.Get("dedicated_host_group").String())
 	isDedicated := !((dedicatedHost == "") && (dedicatedHostGroup == ""))
+	name := d.Get("name").String()
 
 	boot_volume := make([]struct {
 		Name string
@@ -59,9 +60,10 @@ func newIsInstance(d *schema.ResourceData, u *schema.UsageData) *schema.Resource
 	r.PopulateUsage(u)
 
 	configuration := make(map[string]any)
-	configuration["region"] = region
-	configuration["profile"] = profile
+	configuration["name"] = name
 	configuration["on_dedicated_host"] = isDedicated
+	configuration["profile"] = profile
+	configuration["region"] = region
 
 	SetCatalogMetadata(d, d.Type, configuration)
 

--- a/internal/providers/terraform/ibm/testdata/is_instance_test/is_instance_test.golden
+++ b/internal/providers/terraform/ibm/testdata/is_instance_test/is_instance_test.golden
@@ -1,42 +1,54 @@
 
- Name                                                        Monthly Qty  Unit                        Monthly Cost 
-                                                                                                                   
- ibm_is_instance.testBalancedInstance                                                                              
- ├─ CPU hours (32 CPUs, us-east-1)                                23,360  CPU hours                        $583.71 
- ├─ Memory hours (128 GB, us-east-1)                              93,440  Memory hours                     $473.58 
- └─ Storage GB hours (600 GB * 2, us-east-1)                     876,000  Storage GB hours                 $100.32 
-                                                                                                                   
- ibm_is_instance.testBalancedInstanceWithBootVolume                                                                
- ├─ CPU hours (8 CPUs, us-east-1)                                  5,840  CPU hours                        $145.93 
- ├─ Memory hours (32 GB, us-east-1)                               23,360  Memory hours                     $118.40 
- └─ Boot volume (boot-volume-label, 150 GB)                      109,500  GB Hours                          $12.59 
-                                                                                                                   
- ibm_is_instance.testComputeInstance                                                                               
- ├─ CPU hours (2 CPUs, us-east-1)                                  1,460  CPU hours                         $36.48 
- └─ Memory hours (4 GB, us-east-1)                                 2,920  Memory hours                      $22.02 
-                                                                                                                   
- ibm_is_instance.testGpuInstance                                                                                   
- ├─ CPU hours (16 CPUs, us-east-1)                                11,680  CPU hours                        $311.82 
- ├─ Memory hours (128 GB, us-east-1)                              93,440  Memory hours                     $371.90 
- └─ Gpu hours (2 GPUs, Tesla V100, us-east-1)                      1,460  Gpu hours                      $3,051.40 
-                                                                                                                   
- ibm_is_instance.testIbmZInstance                                                                                  
- ├─ CPU hours (16 CPUs, us-east-1)                                11,680  CPU hours                        $530.34 
- └─ Memory hours (64 GB, us-east-1)                               46,720  Memory hours                     $407.71 
-                                                                                                                   
- ibm_is_instance.testInstanceWithoutUsage                                                                          
- ├─ CPU hours (2 CPUs, us-east-1)                    Monthly cost depends on usage: $0.0249876337 per CPU hours    
- └─ Memory hours (4 GB, us-east-1)                   Monthly cost depends on usage: $0.0075416569 per Memory hours 
-                                                                                                                   
- ibm_is_vpc.testVpc                                                                                                
- ├─ VPC instance                                                       1  Instance                           $0.00 
- ├─ VPC egress free allowance (first 5GB)            Monthly cost depends on usage: $0.00 per GB                   
- └─ VPC egress us-east (first 9995 GB)               Monthly cost depends on usage: $0.090915 per GB               
- └─ VPC egress us-east (next 40000 GB)               Monthly cost depends on usage: $0.086735 per GB               
- └─ VPC egress us-east (next 100000 GB)              Monthly cost depends on usage: $0.07315 per GB                
- └─ VPC egress us-east (over 149995 GB)              Monthly cost depends on usage: $0.05225 per GB                
-                                                                                                                   
- OVERALL TOTAL                                                                                           $6,166.19 
+ Name                                                                Monthly Qty  Unit                        Monthly Cost 
+                                                                                                                           
+ ibm_is_instance.testBalancedInstance                                                                                      
+ ├─ CPU hours (32 CPUs, us-east-1) (first 1 CPU hours)                         1  CPU hours                          $0.31 
+ ├─ CPU hours (32 CPUs, us-east-1) (over 0 CPU hours)                          1  CPU hours                          $0.02 
+ ├─ Memory hours (128 GB, us-east-1) (first 1 Memory hours)                    1  Memory hours                       $0.57 
+ ├─ Memory hours (128 GB, us-east-1) (over 0 Memory hours)                     1  Memory hours                       $0.01 
+ └─ Storage GB hours (600 GB * 2, us-east-1)                             876,000  Storage GB hours              $23,652.00 
+                                                                                                                           
+ ibm_is_instance.testBalancedInstanceWithBootVolume                                                                        
+ ├─ CPU hours (8 CPUs, us-east-1) (first 1 CPU hours)                          1  CPU hours                          $0.31 
+ ├─ CPU hours (8 CPUs, us-east-1) (over 0 CPU hours)                           1  CPU hours                          $0.02 
+ ├─ Memory hours (32 GB, us-east-1) (first 1 Memory hours)                     1  Memory hours                       $0.57 
+ ├─ Memory hours (32 GB, us-east-1) (over 0 Memory hours)                      1  Memory hours                       $0.01 
+ └─ Boot volume (boot-volume-label, 150 GB)                              109,500  GB Hours                          $12.59 
+                                                                                                                           
+ ibm_is_instance.testComputeInstance                                                                                       
+ ├─ CPU hours (2 CPUs, us-east-1) (first 1 CPU hours)                          1  CPU hours                          $0.31 
+ ├─ CPU hours (2 CPUs, us-east-1) (over 0 CPU hours)                           1  CPU hours                          $0.02 
+ └─ Memory hours (4 GB, us-east-1) (first 1 Memory hours)                      1  Memory hours                       $0.84 
+ └─ Memory hours (4 GB, us-east-1) (over 0 Memory hours)                       1  Memory hours                       $0.01 
+                                                                                                                           
+ ibm_is_instance.testGpuInstance                                                                                           
+ ├─ CPU hours (16 CPUs, us-east-1) (first 1 CPU hours)                         1  CPU hours                          $0.33 
+ ├─ CPU hours (16 CPUs, us-east-1) (over 0 CPU hours)                          1  CPU hours                          $0.03 
+ ├─ Memory hours (128 GB, us-east-1) (first 1 Memory hours)                    1  Memory hours                       $0.45 
+ ├─ Memory hours (128 GB, us-east-1) (over 0 Memory hours)                     1  Memory hours                       $0.00 
+ └─ Gpu hours (2 GPUs, Tesla V100, us-east-1)                              1,460  Gpu hours                      $3,051.40 
+                                                                                                                           
+ ibm_is_instance.testIbmZInstance                                                                                          
+ ├─ CPU hours (16 CPUs, us-east-1) (first 1 CPU hours)                         1  CPU hours                          $0.39 
+ ├─ CPU hours (16 CPUs, us-east-1) (over 0 CPU hours)                          1  CPU hours                          $0.05 
+ └─ Memory hours (64 GB, us-east-1) (first 1 Memory hours)                     1  Memory hours                       $0.56 
+ └─ Memory hours (64 GB, us-east-1) (over 0 Memory hours)                      1  Memory hours                       $0.01 
+                                                                                                                           
+ ibm_is_instance.testInstanceWithoutUsage                                                                                  
+ ├─ CPU hours (2 CPUs, us-east-1) (first 1 CPU hours)        Monthly cost depends on usage: $0.31 per CPU hours            
+ ├─ CPU hours (2 CPUs, us-east-1) (over 0 CPU hours)         Monthly cost depends on usage: $0.0249876337 per CPU hours    
+ └─ Memory hours (4 GB, us-east-1) (first 1 Memory hours)    Monthly cost depends on usage: $0.84 per Memory hours         
+ └─ Memory hours (4 GB, us-east-1) (over 0 Memory hours)     Monthly cost depends on usage: $0.0075416569 per Memory hours 
+                                                                                                                           
+ ibm_is_vpc.testVpc                                                                                                        
+ ├─ VPC instance                                                               1  Instance                           $0.00 
+ ├─ VPC egress free allowance (first 5GB)                    Monthly cost depends on usage: $0.00 per GB                   
+ └─ VPC egress us-east (first 9995 GB)                       Monthly cost depends on usage: $0.090915 per GB               
+ └─ VPC egress us-east (next 40000 GB)                       Monthly cost depends on usage: $0.086735 per GB               
+ └─ VPC egress us-east (next 100000 GB)                      Monthly cost depends on usage: $0.07315 per GB                
+ └─ VPC egress us-east (over 149995 GB)                      Monthly cost depends on usage: $0.05225 per GB                
+                                                                                                                           
+ OVERALL TOTAL                                                                                                  $26,720.80 
 ──────────────────────────────────
 9 cloud resources were detected:
 ∙ 7 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file


### PR DESCRIPTION
### Changes

* Extract `name` property from Terraform resource `ibm_is_instance`
* Include `name` property in `metadata.catalog` object within the `cost.json` Infracost output
* Update `ibm_is_instance` test golden file

### Testing

#### `cost.json` Snippet

```json
"metadata": {
  "catalog": {
    "childResources": ["ibm_is_ssh_key", "ibm_is_floating_ip"],
    "configuration": {
      "name": "test-instance-1",
      "on_dedicated_host": false,
      "profile": "bx2d-32x128",
      "region": "us-east"
    },
    "pricingUrl": "https://cloud.ibm.com/vpc-ext/provision/vs",
    "serviceId": "is.instance"
  }
}
```


#### Regression Tests

```
 PASS  __tests__/regression/sanityGenEstimate.test.js (10.607 s)
  ✓ Generate estimate for SLZ (2299 ms)
  ✓ Generate estimate for SLZ using usage file (1804 ms)
  ✓ Create usage file for SAP power (1375 ms)
  ✓ Generate estimate for Power infrastructure (1000 ms)
  ✓ Generate estimate for SAP on Power instances (817 ms)
  ✓ Generate estimate for SLZ with Roks (1428 ms)
  ✓ Generate multi-plan estimate using config file (1602 ms)

----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |       0 |        0 |       0 |       0 |                   
----------|---------|----------|---------|---------|-------------------

=============================== Coverage summary ===============================
Statements   : Unknown% ( 0/0 )
Branches     : Unknown% ( 0/0 )
Functions    : Unknown% ( 0/0 )
Lines        : Unknown% ( 0/0 )
================================================================================
Test Suites: 2 passed, 2 total
Tests:       11 passed, 11 total
Snapshots:   0 total
Time:        10.733 s, estimated 11 s
Ran all test suites matching /sanity*/i.
```