### PR TITLE
Add 'multitenant' mode for elasticsearch and postgresql db resources

### DIFF
--- a/internal/providers/terraform/ibm/testdata/database_test/database_test.golden
+++ b/internal/providers/terraform/ibm/testdata/database_test/database_test.golden
@@ -1,44 +1,49 @@
 
- Name                                                      Monthly Qty  Unit    Monthly Cost 
-                                                                                             
- ibm_database.elasticsearch_enterprise                                                       
- ├─ RAM (3 members)                                                336  GB         $5,433.46 
- ├─ Disk (3 members)                                            12,288  GB         $7,720.55 
- └─ Virtual Processor Cores (3 members)                             84  CPU        $2,716.73 
-                                                                                             
- ibm_database.elasticsearch_enterprise_flavor                                                
- ├─ Host Flavor (3 members, m3c.30x240.encrypted)                    3  Flavor    $14,553.90 
- └─ Disk (3 members)                                            12,288  GB         $7,720.55 
-                                                                                             
- ibm_database.elasticsearch_enterprise_multitenant_flavor                                    
- ├─ RAM (3 members)                                                336  GB         $5,433.46 
- ├─ Disk (3 members)                                            12,288  GB         $7,720.55 
- └─ Virtual Processor Cores (3 members)                              6  CPU          $194.05 
-                                                                                             
- ibm_database.elasticsearch_platinum                                                         
- ├─ RAM (3 members)                                                336  GB         $9,032.69 
- ├─ Disk (3 members)                                            12,288  GB         $7,720.55 
- └─ Virtual Processor Cores (3 members)                             84  CPU        $2,716.73 
-                                                                                             
- ibm_database.elasticsearch_platinum_flavor                                                  
- ├─ Host Flavor (3 members, m3c.30x240.encrypted)                    3  Flavor    $22,266.54 
- └─ Disk (3 members)                                            12,288  GB         $7,720.55 
-                                                                                             
- ibm_database.postgresql_standard                                                            
- ├─ RAM (2 members)                                                224  GB         $1,206.67 
- ├─ Disk (2 members)                                             8,192  GB         $5,147.03 
- └─ Virtual Processor Cores (2 members)                             56  CPU        $1,811.15 
-                                                                                             
- ibm_database.postgresql_standard_flavor                                                     
- ├─ Host Flavor (2 members, m3c.30x240.encrypted)                    2  Flavor     $4,526.23 
- └─ Disk (2 members)                                             8,192  GB         $5,147.03 
-                                                                                             
- ibm_database.postgresql_standard_multitenant_flavor                                         
- ├─ RAM (2 members)                                                224  GB         $1,206.67 
- ├─ Disk (2 members)                                             8,192  GB         $5,147.03 
- └─ Virtual Processor Cores (2 members)                              6  CPU          $194.05 
-                                                                                             
- OVERALL TOTAL                                                                   $125,336.17 
+ Name                                                                     Monthly Qty  Unit    Monthly Cost 
+                                                                                                            
+ ibm_database.elasticsearch_enterprise                                                                      
+ ├─ RAM (3 members)                                                               336  GB         $5,433.46 
+ ├─ Disk (3 members)                                                           12,288  GB         $7,720.55 
+ └─ Virtual Processor Cores (3 members)                                            84  CPU        $2,716.73 
+                                                                                                            
+ ibm_database.elasticsearch_enterprise_flavor                                                               
+ ├─ Host Flavor (3 members, m3c.30x240.encrypted)                                   3  Flavor    $14,553.90 
+ └─ Disk (3 members)                                                           12,288  GB         $7,720.55 
+                                                                                                            
+ ibm_database.elasticsearch_enterprise_multitenant_flavor                                                   
+ ├─ RAM (3 members)                                                               336  GB         $5,433.46 
+ ├─ Disk (3 members)                                                           12,288  GB         $7,720.55 
+ └─ Virtual Processor Cores (3 members)                                            84  CPU        $2,716.73 
+                                                                                                            
+ ibm_database.elasticsearch_enterprise_multitenant_flavor_auto_cpu_scale                                    
+ ├─ RAM (3 members)                                                               336  GB         $5,433.46 
+ ├─ Disk (3 members)                                                           12,288  GB         $7,720.55 
+ └─ Virtual Processor Cores (3 members)                                             6  CPU          $194.05 
+                                                                                                            
+ ibm_database.elasticsearch_platinum                                                                        
+ ├─ RAM (3 members)                                                               336  GB         $9,032.69 
+ ├─ Disk (3 members)                                                           12,288  GB         $7,720.55 
+ └─ Virtual Processor Cores (3 members)                                            84  CPU        $2,716.73 
+                                                                                                            
+ ibm_database.elasticsearch_platinum_flavor                                                                 
+ ├─ Host Flavor (3 members, m3c.30x240.encrypted)                                   3  Flavor    $22,266.54 
+ └─ Disk (3 members)                                                           12,288  GB         $7,720.55 
+                                                                                                            
+ ibm_database.postgresql_standard                                                                           
+ ├─ RAM (2 members)                                                               224  GB         $1,206.67 
+ ├─ Disk (2 members)                                                            8,192  GB         $5,147.03 
+ └─ Virtual Processor Cores (2 members)                                            56  CPU        $1,811.15 
+                                                                                                            
+ ibm_database.postgresql_standard_flavor                                                                    
+ ├─ Host Flavor (2 members, m3c.30x240.encrypted)                                   2  Flavor     $4,526.23 
+ └─ Disk (2 members)                                                            8,192  GB         $5,147.03 
+                                                                                                            
+ ibm_database.postgresql_standard_multitenant_flavor                                                        
+ ├─ RAM (2 members)                                                               224  GB         $1,206.67 
+ ├─ Disk (2 members)                                                            8,192  GB         $5,147.03 
+ └─ Virtual Processor Cores (2 members)                                            56  CPU        $1,811.15 
+                                                                                                            
+ OVERALL TOTAL                                                                                  $142,824.00 
 ──────────────────────────────────
-8 cloud resources were detected:
-∙ 8 were estimated
+9 cloud resources were detected:
+∙ 9 were estimated

--- a/internal/providers/terraform/ibm/testdata/database_test/database_test.golden
+++ b/internal/providers/terraform/ibm/testdata/database_test/database_test.golden
@@ -1,34 +1,44 @@
 
- Name                                              Monthly Qty  Unit    Monthly Cost 
-                                                                                     
- ibm_database.elasticsearch_enterprise                                               
- ├─ RAM (3 members)                                        336  GB         $5,433.46 
- ├─ Disk (3 members)                                    12,288  GB         $7,720.55 
- └─ Virtual Processor Cores (3 members)                     84  CPU        $2,716.73 
-                                                                                     
- ibm_database.elasticsearch_enterprise_flavor                                        
- ├─ Host Flavor (3 members, m3c.30x240.encrypted)            3  Flavor    $14,553.90 
- └─ Disk (3 members)                                    12,288  GB         $7,720.55 
-                                                                                     
- ibm_database.elasticsearch_platinum                                                 
- ├─ RAM (3 members)                                        336  GB         $9,032.69 
- ├─ Disk (3 members)                                    12,288  GB         $7,720.55 
- └─ Virtual Processor Cores (3 members)                     84  CPU        $2,716.73 
-                                                                                     
- ibm_database.elasticsearch_platinum_flavor                                          
- ├─ Host Flavor (3 members, m3c.30x240.encrypted)            3  Flavor    $22,266.54 
- └─ Disk (3 members)                                    12,288  GB         $7,720.55 
-                                                                                     
- ibm_database.postgresql_standard                                                    
- ├─ RAM (2 members)                                        224  GB         $1,206.67 
- ├─ Disk (2 members)                                     8,192  GB         $5,147.03 
- └─ Virtual Processor Cores (2 members)                     56  CPU        $1,811.15 
-                                                                                     
- ibm_database.postgresql_standard_flavor                                             
- ├─ Host Flavor (2 members, m3c.30x240.encrypted)            2  Flavor     $4,526.23 
- └─ Disk (2 members)                                     8,192  GB         $5,147.03 
-                                                                                     
- OVERALL TOTAL                                                           $105,440.36 
+ Name                                                      Monthly Qty  Unit    Monthly Cost 
+                                                                                             
+ ibm_database.elasticsearch_enterprise                                                       
+ ├─ RAM (3 members)                                                336  GB         $5,433.46 
+ ├─ Disk (3 members)                                            12,288  GB         $7,720.55 
+ └─ Virtual Processor Cores (3 members)                             84  CPU        $2,716.73 
+                                                                                             
+ ibm_database.elasticsearch_enterprise_flavor                                                
+ ├─ Host Flavor (3 members, m3c.30x240.encrypted)                    3  Flavor    $14,553.90 
+ └─ Disk (3 members)                                            12,288  GB         $7,720.55 
+                                                                                             
+ ibm_database.elasticsearch_enterprise_multitenant_flavor                                    
+ ├─ RAM (3 members)                                                336  GB         $5,433.46 
+ ├─ Disk (3 members)                                            12,288  GB         $7,720.55 
+ └─ Virtual Processor Cores (3 members)                              6  CPU          $194.05 
+                                                                                             
+ ibm_database.elasticsearch_platinum                                                         
+ ├─ RAM (3 members)                                                336  GB         $9,032.69 
+ ├─ Disk (3 members)                                            12,288  GB         $7,720.55 
+ └─ Virtual Processor Cores (3 members)                             84  CPU        $2,716.73 
+                                                                                             
+ ibm_database.elasticsearch_platinum_flavor                                                  
+ ├─ Host Flavor (3 members, m3c.30x240.encrypted)                    3  Flavor    $22,266.54 
+ └─ Disk (3 members)                                            12,288  GB         $7,720.55 
+                                                                                             
+ ibm_database.postgresql_standard                                                            
+ ├─ RAM (2 members)                                                224  GB         $1,206.67 
+ ├─ Disk (2 members)                                             8,192  GB         $5,147.03 
+ └─ Virtual Processor Cores (2 members)                             56  CPU        $1,811.15 
+                                                                                             
+ ibm_database.postgresql_standard_flavor                                                     
+ ├─ Host Flavor (2 members, m3c.30x240.encrypted)                    2  Flavor     $4,526.23 
+ └─ Disk (2 members)                                             8,192  GB         $5,147.03 
+                                                                                             
+ ibm_database.postgresql_standard_multitenant_flavor                                         
+ ├─ RAM (2 members)                                                224  GB         $1,206.67 
+ ├─ Disk (2 members)                                             8,192  GB         $5,147.03 
+ └─ Virtual Processor Cores (2 members)                              6  CPU          $194.05 
+                                                                                             
+ OVERALL TOTAL                                                                   $125,336.17 
 ──────────────────────────────────
-6 cloud resources were detected:
-∙ 6 were estimated
+8 cloud resources were detected:
+∙ 8 were estimated

--- a/internal/providers/terraform/ibm/testdata/database_test/database_test.golden
+++ b/internal/providers/terraform/ibm/testdata/database_test/database_test.golden
@@ -16,9 +16,9 @@
  └─ Virtual Processor Cores (3 members)                                            84  CPU        $2,716.73 
                                                                                                             
  ibm_database.elasticsearch_enterprise_multitenant_flavor_auto_cpu_scale                                    
- ├─ RAM (3 members)                                                               336  GB         $5,433.46 
- ├─ Disk (3 members)                                                           12,288  GB         $7,720.55 
- └─ Virtual Processor Cores (3 members)                                             6  CPU          $194.05 
+ ├─ RAM (3 members)                                                                12  GB           $194.05 
+ ├─ Disk (3 members)                                                               15  GB             $9.42 
+ └─ Virtual Processor Cores (3 members)                                           1.5  CPU           $48.51 
                                                                                                             
  ibm_database.elasticsearch_platinum                                                                        
  ├─ RAM (3 members)                                                               336  GB         $9,032.69 
@@ -43,7 +43,7 @@
  ├─ Disk (2 members)                                                            8,192  GB         $5,147.03 
  └─ Virtual Processor Cores (2 members)                                            56  CPU        $1,811.15 
                                                                                                             
- OVERALL TOTAL                                                                                  $142,824.00 
+ OVERALL TOTAL                                                                                  $129,727.93 
 ──────────────────────────────────
 9 cloud resources were detected:
 ∙ 9 were estimated

--- a/internal/providers/terraform/ibm/testdata/database_test/database_test.tf
+++ b/internal/providers/terraform/ibm/testdata/database_test/database_test.tf
@@ -24,7 +24,7 @@ resource "ibm_database" "postgresql_standard_flavor" {
     host_flavor {
       id = "m3c.30x240.encrypted"
     }
-    disk {
+    disk { # >= 5120 and <= 4194304 in increments of 1024
       allocation_mb = 4194304
     }
   }
@@ -45,14 +45,14 @@ resource "ibm_database" "postgresql_standard_multitenant_flavor" {
     host_flavor {
       id = "multitenant"
     }
-    disk {
+    disk { # >= 5120 and <= 4194304 in increments of 1024
       allocation_mb = 4194304
     }
-    memory {
+    memory { # >= 4096 and <= 114688 in increments of 128
       allocation_mb = 114688
     }
-    cpu {
-      allocation_count = 3
+    cpu { # >= 0 and <= 28 in increments of 1
+      allocation_count = 28
     }
   }
   configuration = <<CONFIGURATION
@@ -69,13 +69,13 @@ resource "ibm_database" "postgresql_standard" {
   location = "us-south"
   group {
     group_id = "member"
-    memory {
+    memory { # >= 1024 and <= 114688 in increments of 128
       allocation_mb = 114688
     }
-    disk {
+    disk { # >= 5120 and <= 4194304 in increments of 1024
       allocation_mb = 4194304
     }
-    cpu {
+    cpu { # >= 0 and <= 28 in increments of 1
       allocation_count = 28
     }
   }
@@ -97,13 +97,13 @@ resource "ibm_database" "elasticsearch_platinum" {
   location = "us-south"
   group {
     group_id = "member"
-    memory {
+    memory { # >= 1024 and <= 114688 in increments of 128
       allocation_mb = 114688
     }
-    disk {
+    disk { # >= 5120 and <= 4194304 in increments of 1024
       allocation_mb = 4194304
     }
-    cpu {
+    cpu { # >= 0 and <= 28 in increments of 1
       allocation_count = 28
     }
   }
@@ -119,7 +119,7 @@ resource "ibm_database" "elasticsearch_platinum_flavor" {
     host_flavor {
       id = "m3c.30x240.encrypted"
     }
-    disk {
+    disk { # >= 5120 and <= 4194304 in increments of 1024
       allocation_mb = 4194304
     }
   }
@@ -133,13 +133,13 @@ resource "ibm_database" "elasticsearch_enterprise" {
   group {
     group_id = "member"
 
-    memory {
+    memory { # >= 1024 and <= 114688 in increments of 128
       allocation_mb = 114688
     }
-    disk {
+    disk { # >= 5120 and <= 4194304 in increments of 1024
       allocation_mb = 4194304
     }
-    cpu {
+    cpu { # >= 0 and <= 28 in increments of 1
       allocation_count = 28
     }
   }
@@ -155,7 +155,7 @@ resource "ibm_database" "elasticsearch_enterprise_flavor" {
     host_flavor {
       id = "m3c.30x240.encrypted"
     }
-    disk {
+    disk { # >= 5120 and <= 4194304 in increments of 1024
       allocation_mb = 4194304
     }
   }
@@ -171,14 +171,37 @@ resource "ibm_database" "elasticsearch_enterprise_multitenant_flavor" {
     host_flavor {
       id = "multitenant"
     }
-    disk {
+    disk { # >= 5120 and <= 4194304 in increments of 1024
       allocation_mb = 4194304
     }
-    memory {
+    memory { # >= 4096 and <= 114688 in increments of 128
       allocation_mb = 114688
     }
-    cpu {
-      allocation_count = 2
+    cpu { # >= 0 and <= 28 in increments of 1
+      # allocation_count = 0 # Automatically allocate based on a 1:8 ration with RAM
+      allocation_count = 28
+    }
+  }
+}
+
+resource "ibm_database" "elasticsearch_enterprise_multitenant_flavor_auto_cpu_scale" {
+  name     = "elasticsearch-enterprise-multitenant-flavor-auto-cpu-scale"
+  service  = "databases-for-elasticsearch"
+  plan     = "enterprise"
+  location = "us-south"
+  group {
+    group_id = "member"
+    host_flavor {
+      id = "multitenant"
+    }
+    disk { # >= 5120 and <= 4194304 in increments of 1024
+      allocation_mb = 4194304
+    }
+    memory { # >= 4096 and <= 114688 in increments of 128
+      allocation_mb = 114688
+    }
+    cpu {                  # >= 0 and <= 28 in increments of 1
+      allocation_count = 0 # Automatically allocate based on a 1:8 ration with RAM
     }
   }
 }

--- a/internal/providers/terraform/ibm/testdata/database_test/database_test.tf
+++ b/internal/providers/terraform/ibm/testdata/database_test/database_test.tf
@@ -35,6 +35,33 @@ resource "ibm_database" "postgresql_standard_flavor" {
   CONFIGURATION
 }
 
+resource "ibm_database" "postgresql_standard_multitenant_flavor" {
+  name     = "postgres-standard-multitenant-flavour"
+  service  = "databases-for-postgresql"
+  plan     = "standard"
+  location = "us-south"
+  group { # Note: "memory" not allowed when host_flavor is set
+    group_id = "member"
+    host_flavor {
+      id = "multitenant"
+    }
+    disk {
+      allocation_mb = 4194304
+    }
+    memory {
+      allocation_mb = 114688
+    }
+    cpu {
+      allocation_count = 3
+    }
+  }
+  configuration = <<CONFIGURATION
+  {
+    "max_connections": 400
+  }
+  CONFIGURATION
+}
+
 resource "ibm_database" "postgresql_standard" {
   name     = "postgres-standard"
   service  = "databases-for-postgresql"
@@ -98,6 +125,28 @@ resource "ibm_database" "elasticsearch_platinum_flavor" {
   }
 }
 
+# resource "ibm_database" "elasticsearch_platinum_multitenant_flavor" {
+#   name     = "elasticsearch-platinum-multitenant-flavor"
+#   service  = "databases-for-elasticsearch"
+#   plan     = "platinum"
+#   location = "us-south"
+#   group {
+#     group_id = "member"
+#     host_flavor {
+#       id = "multitenant"
+#     }
+#     disk {
+#       allocation_mb = 4194304
+#     }
+#     memory {
+#       allocation_mb = 114688
+#     }
+#     cpu {
+#       allocation_count = 1
+#     }
+#   }
+# }
+
 resource "ibm_database" "elasticsearch_enterprise" {
   name     = "elasticsearch-enterprise"
   service  = "databases-for-elasticsearch"
@@ -130,6 +179,29 @@ resource "ibm_database" "elasticsearch_enterprise_flavor" {
     }
     disk {
       allocation_mb = 4194304
+    }
+  }
+}
+
+
+resource "ibm_database" "elasticsearch_enterprise_multitenant_flavor" {
+  name     = "elasticsearch-enterprise-multitenant-flavor"
+  service  = "databases-for-elasticsearch"
+  plan     = "enterprise"
+  location = "us-south"
+  group {
+    group_id = "member"
+    host_flavor {
+      id = "multitenant"
+    }
+    disk {
+      allocation_mb = 4194304
+    }
+    memory {
+      allocation_mb = 114688
+    }
+    cpu {
+      allocation_count = 2
     }
   }
 }

--- a/internal/providers/terraform/ibm/testdata/database_test/database_test.tf
+++ b/internal/providers/terraform/ibm/testdata/database_test/database_test.tf
@@ -125,28 +125,6 @@ resource "ibm_database" "elasticsearch_platinum_flavor" {
   }
 }
 
-# resource "ibm_database" "elasticsearch_platinum_multitenant_flavor" {
-#   name     = "elasticsearch-platinum-multitenant-flavor"
-#   service  = "databases-for-elasticsearch"
-#   plan     = "platinum"
-#   location = "us-south"
-#   group {
-#     group_id = "member"
-#     host_flavor {
-#       id = "multitenant"
-#     }
-#     disk {
-#       allocation_mb = 4194304
-#     }
-#     memory {
-#       allocation_mb = 114688
-#     }
-#     cpu {
-#       allocation_count = 1
-#     }
-#   }
-# }
-
 resource "ibm_database" "elasticsearch_enterprise" {
   name     = "elasticsearch-enterprise"
   service  = "databases-for-elasticsearch"
@@ -182,7 +160,6 @@ resource "ibm_database" "elasticsearch_enterprise_flavor" {
     }
   }
 }
-
 
 resource "ibm_database" "elasticsearch_enterprise_multitenant_flavor" {
   name     = "elasticsearch-enterprise-multitenant-flavor"

--- a/internal/providers/terraform/ibm/testdata/database_test/database_test.tf
+++ b/internal/providers/terraform/ibm/testdata/database_test/database_test.tf
@@ -184,6 +184,7 @@ resource "ibm_database" "elasticsearch_enterprise_multitenant_flavor" {
   }
 }
 
+# Specifications used by Dev RAG stack
 resource "ibm_database" "elasticsearch_enterprise_multitenant_flavor_auto_cpu_scale" {
   name     = "elasticsearch-enterprise-multitenant-flavor-auto-cpu-scale"
   service  = "databases-for-elasticsearch"
@@ -195,10 +196,10 @@ resource "ibm_database" "elasticsearch_enterprise_multitenant_flavor_auto_cpu_sc
       id = "multitenant"
     }
     disk { # >= 5120 and <= 4194304 in increments of 1024
-      allocation_mb = 4194304
+      allocation_mb = 5120
     }
     memory { # >= 4096 and <= 114688 in increments of 128
-      allocation_mb = 114688
+      allocation_mb = 4096
     }
     cpu {                  # >= 0 and <= 28 in increments of 1
       allocation_count = 0 # Automatically allocate based on a 1:8 ration with RAM

--- a/internal/resources/ibm/database_elasticsearch.go
+++ b/internal/resources/ibm/database_elasticsearch.go
@@ -2,6 +2,7 @@ package ibm
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 
 	"github.com/infracost/infracost/internal/schema"
@@ -25,11 +26,18 @@ func GetElasticSearchCostComponents(r *Database) []*schema.CostComponent {
 }
 
 func ElasticSearchVirtualProcessorCoreCostComponent(r *Database) *schema.CostComponent {
+
+	var q float64 = float64(r.CPU)
+	if r.Flavor == "multitenant" && q == 0 {
+		// Calculate CPU as 1:8 ratio with RAM, with a max of 2 CPU https://cloud.ibm.com/docs/databases-for-elasticsearch?topic=databases-for-elasticsearch-resources-scaling&interface=terraform
+		q = math.Min(float64(r.Memory/1024)/8, 2)
+	}
+
 	return &schema.CostComponent{
 		Name:            fmt.Sprintf("Virtual Processor Cores (%s members)", strconv.FormatInt(r.Members, 10)),
 		Unit:            "CPU",
 		UnitMultiplier:  decimal.NewFromInt(1), // Final quantity for this cost component will be divided by this amount
-		MonthlyQuantity: decimalPtr(decimal.NewFromInt(r.CPU * r.Members)),
+		MonthlyQuantity: decimalPtr(decimal.NewFromFloat(float64(q) * float64(r.Members))),
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr("ibm"),
 			Region:        strPtr(r.Location),
@@ -114,7 +122,7 @@ func ElasticSearchHostFlavorComponent(r *Database) *schema.CostComponent {
 		Name:            fmt.Sprintf("Host Flavor (%s members, %s)", strconv.FormatInt(r.Members, 10), r.Flavor),
 		Unit:            "Flavor",
 		UnitMultiplier:  decimal.NewFromInt(1), // Final quantity for this cost component will be divided by this amount
-		MonthlyQuantity: decimalPtr(decimal.NewFromInt(r.Members)),
+		MonthlyQuantity: decimalPtr(decimal.NewFromFloat(float64(r.Members))),
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr("ibm"),
 			Region:        strPtr(r.Location),

--- a/internal/resources/ibm/database_elasticsearch.go
+++ b/internal/resources/ibm/database_elasticsearch.go
@@ -10,7 +10,7 @@ import (
 
 func GetElasticSearchCostComponents(r *Database) []*schema.CostComponent {
 
-	if r.Flavor != "" {
+	if r.Flavor != "" && r.Flavor != "multitenant" {
 		return []*schema.CostComponent{
 			ElasticSearchHostFlavorComponent(r),
 			ElasticSearchDiskCostComponent(r),

--- a/internal/resources/ibm/database_postgresql.go
+++ b/internal/resources/ibm/database_postgresql.go
@@ -10,7 +10,7 @@ import (
 
 func GetPostgresCostComponents(r *Database) []*schema.CostComponent {
 
-	if r.Flavor != "" {
+	if r.Flavor != "" && r.Flavor != "multitenant" {
 		return []*schema.CostComponent{
 			PostgresHostFlavorComponent(r),
 			PostgresDiskCostComponent(r),


### PR DESCRIPTION
Add support for `multitenant` flag to be used as `host_flavor.id` property in the [`ibm_database`](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/database) resource.

For example:

```tf
resource "ibm_database" "elasticsearch_enterprise_multitenant_flavor_auto_cpu_scale" {
  name     = "elasticsearch-enterprise-multitenant-flavor-auto-cpu-scale"
  service  = "databases-for-elasticsearch"
  plan     = "enterprise"
  location = "us-south"
  group {
    group_id = "member"
    host_flavor {
      id = "multitenant"
    }
    disk { # >= 5120 and <= 4194304 in increments of 1024
      allocation_mb = 5120
    }
    memory { # >= 4096 and <= 114688 in increments of 128
      allocation_mb = 4096
    }
    cpu {                  # >= 0 and <= 28 in increments of 1
      allocation_count = 0 # Automatically allocate based on a 1:8 ration with RAM
    }
  }
}
```

Would have a cost breakdown:

```
 ibm_database.elasticsearch_enterprise_multitenant_flavor_auto_cpu_scale                                    
 ├─ RAM (3 members)                                                                12  GB           $194.05 
 ├─ Disk (3 members)                                                               15  GB             $9.42 
 └─ Virtual Processor Cores (3 members)                                           1.5  CPU           $48.51 
```
<details>
<summary>Expected cost, provided by user (IBM DA team)</summary>

<img src="https://github.com/user-attachments/assets/efb62f34-7ec0-4bc6-a43f-50262786473d">

</details>

