### PR TITLE
Update attributes filter for vpc vsi's to always use ocpIncluded when querying for pricing

### DIFF
--- a/internal/resources/ibm/container_vpc_cluster.go
+++ b/internal/resources/ibm/container_vpc_cluster.go
@@ -77,6 +77,10 @@ func (r *ContainerVpcCluster) BuildResource() *schema.Resource {
 		attributeFilters = append(attributeFilters, &schema.AttributeFilter{
 			Key: "ocpIncluded", Value: strPtr("true"),
 		})
+	} else {
+		attributeFilters = append(attributeFilters, &schema.AttributeFilter{
+			Key: "ocpIncluded", Value: strPtr("false"),
+		})
 	}
 	WorkerCount := decimalPtr(decimal.NewFromInt(1))
 	if r.WorkerCount != 0 {

--- a/internal/resources/ibm/container_vpc_worker_pool.go
+++ b/internal/resources/ibm/container_vpc_worker_pool.go
@@ -70,6 +70,10 @@ func (r *ContainerVpcWorkerPool) BuildResource() *schema.Resource {
 		attributeFilters = append(attributeFilters, &schema.AttributeFilter{
 			Key: "ocpIncluded", Value: strPtr("true"),
 		})
+	} else {
+		attributeFilters = append(attributeFilters, &schema.AttributeFilter{
+			Key: "ocpIncluded", Value: strPtr("false"),
+		})
 	}
 	WorkerCount := decimalPtr(decimal.NewFromInt(1))
 	if r.WorkerCount != 0 {


### PR DESCRIPTION
The ocpIncluded attribute indicates whether the prices include OCP charges. These prices are used when the user does not already have or are not providing an existing entitlement.