### PR TITLE
Patch CWE-601: Unvalidated/Open Redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ VSWorkspaceState.json
 *.out
 
 # Local
-.env.local
+.env*
 vendor/
 
 # Terraform artifacts

--- a/cmd/infracost/main.go
+++ b/cmd/infracost/main.go
@@ -175,7 +175,7 @@ func newRootCmd(ctx *config.RunContext) *cobra.Command {
 	rootCmd.PersistentFlags().Bool("debug-report", false, "Generate a debug report file which can be sent to Infracost team")
 
 	rootCmd.AddCommand(authCmd(ctx))
-	rootCmd.AddCommand(registerCmd(ctx))
+	// rootCmd.AddCommand(registerCmd(ctx))
 	rootCmd.AddCommand(configureCmd(ctx))
 	rootCmd.AddCommand(diffCmd(ctx))
 	rootCmd.AddCommand(breakdownCmd(ctx))


### PR DESCRIPTION
Remove access to register command `infracost auth login`; we don't use this flow.