### PR TITLE
Add `trial` plan support for Secrets Manager

### DIFF
--- a/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.golden
+++ b/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.golden
@@ -117,9 +117,12 @@
  ibm_resource_instance.resource_instance_power_iaas                                                                                          
  └─ Workspace for Power Virtual Server                                                       1  Workspace                              $0.00 
                                                                                                                                              
- ibm_resource_instance.resource_instance_secrets_manager                                                                                     
+ ibm_resource_instance.resource_instance_secrets_manager_standard                                                                            
  ├─ Instance                                                                                 1  Instance                             $321.00 
  └─ Active Secrets                                                                         400  Secrets                               $86.00 
+                                                                                                                                             
+ ibm_resource_instance.resource_instance_secrets_manager_trial                                                                               
+ └─ Trial plan                                                                               1                                         $0.00 
                                                                                                                                              
  ibm_resource_instance.scc_standard                                                                                                          
  └─ Evaluations                                                                          1,000  Evaluations                           $13.39 

--- a/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.tf
+++ b/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.tf
@@ -18,10 +18,18 @@ resource "ibm_resource_instance" "resource_instance_kms" {
   resource_group_id = "default"
 }
 
-resource "ibm_resource_instance" "resource_instance_secrets_manager" {
+resource "ibm_resource_instance" "resource_instance_secrets_manager_standard" {
   name              = "test"
   service           = "secrets-manager"
   plan              = "standard"
+  location          = "us-south"
+  resource_group_id = "default"
+}
+
+resource "ibm_resource_instance" "resource_instance_secrets_manager_trial" {
+  name              = "test"
+  service           = "secrets-manager"
+  plan              = "trial"
   location          = "us-south"
   resource_group_id = "default"
 }

--- a/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.usage.yml
+++ b/internal/providers/terraform/ibm/testdata/resource_instance_test/resource_instance_test.usage.yml
@@ -2,7 +2,7 @@ version: 0.1
 resource_usage:
   ibm_resource_instance.resource_instance_kms:
     kms_key_versions: 300
-  ibm_resource_instance.resource_instance_secrets_manager:
+  ibm_resource_instance.resource_instance_secrets_manager_standard:
     secretsmanager_instance: 1
     secretsmanager_active_secrets: 400
   ibm_resource_instance.resource_instance_appid:

--- a/internal/resources/ibm/resource_instance.go
+++ b/internal/resources/ibm/resource_instance.go
@@ -312,7 +312,25 @@ func SecretsManagerActiveSecretsCostComponent(r *ResourceInstance) *schema.CostC
 }
 
 func GetSecretsManagerCostComponents(r *ResourceInstance) []*schema.CostComponent {
-	if r.Plan == "standard" {
+	if r.Plan == "trial" {
+		costComponent := schema.CostComponent{
+			Name:            "Trial plan",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+			ProductFilter: &schema.ProductFilter{
+				VendorName: strPtr("ibm"),
+				Region:     strPtr(r.Location),
+				Service:    &r.Service,
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "planName", Value: &r.Plan},
+				},
+			},
+		}
+		costComponent.SetCustomPrice(decimalPtr(decimal.NewFromInt(0)))
+		return []*schema.CostComponent{
+			&costComponent,
+		}
+	} else if r.Plan == "standard" {
 		return []*schema.CostComponent{
 			SecretsManagerInstanceCostComponent(r),
 			SecretsManagerActiveSecretsCostComponent(r),


### PR DESCRIPTION
Add support for plan `trial` under `secrets-manager`, such that the price displayed is $0.