### PR TITLE
Update is_floating_ip golden file

### DIFF
--- a/internal/providers/terraform/ibm/testdata/is_floating_ip_test/is_floating_ip_test.golden
+++ b/internal/providers/terraform/ibm/testdata/is_floating_ip_test/is_floating_ip_test.golden
@@ -1,24 +1,22 @@
 
- Name                                                               Monthly Qty  Unit                        Monthly Cost 
-                                                                                                                          
- ibm_is_floating_ip.testFloatingIp                                                                                        
- └─ Floating IP us-south                                                      1  Instance                           $1.05 
-                                                                                                                          
- ibm_is_instance.testInstance                                                                                             
- ├─ CPU hours (2 CPUs, us-south-1) (first 1 CPU hours)      Monthly cost depends on usage: $0.31 per CPU hours            
- ├─ CPU hours (2 CPUs, us-south-1) (over 0 CPU hours)       Monthly cost depends on usage: $0.0249876337 per CPU hours    
- └─ Memory hours (8 GB, us-south-1) (first 1 Memory hours)  Monthly cost depends on usage: $0.57 per Memory hours         
- └─ Memory hours (8 GB, us-south-1) (over 0 Memory hours)   Monthly cost depends on usage: $0.00506833 per Memory hours   
-                                                                                                                          
- ibm_is_vpc.testVpc                                                                                                       
- ├─ VPC instance                                                              1  Instance                           $0.00 
- ├─ VPC egress free allowance (first 5GB)                   Monthly cost depends on usage: $0.00 per GB                   
- └─ VPC egress us-south (first 9995 GB)                     Monthly cost depends on usage: $0.090915 per GB               
- └─ VPC egress us-south (next 40000 GB)                     Monthly cost depends on usage: $0.086735 per GB               
- └─ VPC egress us-south (next 100000 GB)                    Monthly cost depends on usage: $0.07315 per GB                
- └─ VPC egress us-south (over 149995 GB)                    Monthly cost depends on usage: $0.05225 per GB                
-                                                                                                                          
- OVERALL TOTAL                                                                                                      $1.05 
+ Name                                               Monthly Qty  Unit                  Monthly Cost 
+                                                                                                    
+ ibm_is_floating_ip.testFloatingIp                                                                  
+ └─ Floating IP us-south                                      1  Instance                     $1.05 
+                                                                                                    
+ ibm_is_instance.testInstance                                                                       
+ ├─ Instance Hours (bx2-2x8)                   Monthly cost depends on usage: $0.10 per Hours       
+ └─ Boot volume (Unnamed boot volume, 100 GB)  Monthly cost depends on usage: $0.00011495 per Hours 
+                                                                                                    
+ ibm_is_vpc.testVpc                                                                                 
+ ├─ VPC instance                                              1  Instance                     $0.00 
+ ├─ VPC egress free allowance (first 5GB)      Monthly cost depends on usage: $0.00 per GB          
+ └─ VPC egress us-south (first 9995 GB)        Monthly cost depends on usage: $0.090915 per GB      
+ └─ VPC egress us-south (next 40000 GB)        Monthly cost depends on usage: $0.086735 per GB      
+ └─ VPC egress us-south (next 100000 GB)       Monthly cost depends on usage: $0.07315 per GB       
+ └─ VPC egress us-south (over 149995 GB)       Monthly cost depends on usage: $0.05225 per GB       
+                                                                                                    
+ OVERALL TOTAL                                                                                $1.05 
 ──────────────────────────────────
 6 cloud resources were detected:
 ∙ 3 were estimated, 2 of which include usage-based costs, see https://infracost.io/usage-file


### PR DESCRIPTION
This commit updates the golden file for the is_floating_ip test case.

The update is required as the `ibm_is_instance` resource values have changed. The new values are consistent with the one shown on UI.

To run test:
`go test ./internal/providers/terraform/ibm/is_floating_ip_test.go -v`