### PR TITLE
Issue #452: Cost estimation misses cost for image used for PowerVS Instances

### DIFF
--- a/internal/providers/terraform/ibm/pi_instance.go
+++ b/internal/providers/terraform/ibm/pi_instance.go
@@ -32,7 +32,7 @@ func identifyOperatingSystem(imageName string) int64 {
 		return ibm.IBMI
 	}
 
-	if truncatedImageName == "CentOS" || truncatedImageName == "Linux" || truncatedImageName == "RHEL8" {
+	if truncatedImageName == "CentOS" || truncatedImageName == "Linux" || truncatedImageName == "RHEL8" || truncatedImageName == "RHEL9" {
 		return ibm.RHEL
 	}
 
@@ -66,6 +66,8 @@ func newPiInstance(d *schema.ResourceData, u *schema.UsageData) *schema.Resource
 
 	if len(refs) > 0 {
 		imageName = refs[0].Get("pi_image_name").String()
+	} else {
+		imageName = d.Get("pi_image_id").String()
 	}
 
 	region := d.Get("region").String()

--- a/internal/providers/terraform/ibm/testdata/pi_instance_test/pi_instance_test.golden
+++ b/internal/providers/terraform/ibm/testdata/pi_instance_test/pi_instance_test.golden
@@ -11,13 +11,13 @@
  ├─ Storage - tier1                                                            14,600  GB hours                       $4.00 
  ├─ Linux HANA Memory                                                          93,440  Memory hours                 $289.66 
  ├─ Linux HANA Cores                                                            2,920  Core hours                 $1,279.54 
- └─ Linux HANA OS                                                                 730  Instance hours               $496.40 
+ └─ Linux HANA OS for SLES                                                        730  Instance hours               $496.40 
                                                                                                                             
  ibm_pi_instance.hana-dedicated-e980-instance_no_quantity                                                                   
  ├─ Storage - tier1                                                 Monthly cost depends on usage: $0.000274 per GB hours   
  ├─ Linux HANA Memory                                               Monthly cost depends on usage: $0.0031 per Memory hours 
  ├─ Linux HANA Cores                                                Monthly cost depends on usage: $0.44 per Core hours     
- └─ Linux HANA OS                                                   Monthly cost depends on usage: $0.68 per Instance hours 
+ └─ Linux HANA OS for SLES                                          Monthly cost depends on usage: $0.68 per Instance hours 
                                                                                                                             
  ibm_pi_instance.ibmi-dedicated-e980-instance                                                                               
  ├─ Storage - tier1                                                            14,600  GB hours                       $4.00 
@@ -42,17 +42,23 @@
  ibm_pi_instance.netweaver-shared-s922-instance                                                                             
  ├─ Storage - tier1                                                            14,600  GB hours                       $4.00 
  ├─ Cores                                                                         730  Core hours                    $92.23 
- └─ Memory                                                                        730  GB hours                       $8.70 
+ ├─ Memory                                                                        730  GB hours                       $8.70 
+ └─ Image cost (Licence Fee) for SLES (first 1 GB hours)                            1  GB hours                       $0.10 
+ └─ Image cost (Licence Fee) for SLES (next 2 GB hours)                             2  GB hours                       $0.20 
+ └─ Image cost (Licence Fee) for SLES (over 3 GB hours)                             2  GB hours                       $0.40 
                                                                                                                             
  ibm_pi_instance.netweaver-shared-s922-no-usage-specified-instance                                                          
  ├─ Storage - tier1                                                 Monthly cost depends on usage: $0.000274 per GB hours   
  ├─ Cores                                                           Monthly cost depends on usage: $0.13 per Core hours     
- └─ Memory                                                          Monthly cost depends on usage: $0.011913 per GB hours   
+ ├─ Memory                                                          Monthly cost depends on usage: $0.011913 per GB hours   
+ └─ Image cost (Licence Fee) for SLES (first 1 GB hours)            Monthly cost depends on usage: $0.10 per GB hours       
+ └─ Image cost (Licence Fee) for SLES (next 2 GB hours)             Monthly cost depends on usage: $0.10 per GB hours       
+ └─ Image cost (Licence Fee) for SLES (over 3 GB hours)             Monthly cost depends on usage: $0.20 per GB hours       
                                                                                                                             
  ibm_resource_instance.powervs_service                                                                                      
  └─ Workspace for Power Virtual Server                                              1  Workspace                      $0.00 
                                                                                                                             
- OVERALL TOTAL                                                                                                    $6,529.42 
+ OVERALL TOTAL                                                                                                    $6,530.12 
 ──────────────────────────────────
 14 cloud resources were detected:
 ∙ 8 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/ibm/testdata/pi_instance_test/pi_instance_test.golden
+++ b/internal/providers/terraform/ibm/testdata/pi_instance_test/pi_instance_test.golden
@@ -11,13 +11,17 @@
  ├─ Storage - tier1                                                            14,600  GB hours                       $4.00 
  ├─ Linux HANA Memory                                                          93,440  Memory hours                 $289.66 
  ├─ Linux HANA Cores                                                            2,920  Core hours                 $1,279.54 
- └─ Linux HANA OS for SLES                                                        730  Instance hours               $496.40 
+ └─ Linux HANA OS for SLES (first 1 Instance hours)                                 1  Instance hours                 $0.34 
+ └─ Linux HANA OS for SLES (next 2 Instance hours)                                  2  Instance hours                 $1.36 
+ └─ Linux HANA OS for SLES (over 3 Instance hours)                                  2  Instance hours                 $1.64 
                                                                                                                             
  ibm_pi_instance.hana-dedicated-e980-instance_no_quantity                                                                   
  ├─ Storage - tier1                                                 Monthly cost depends on usage: $0.000274 per GB hours   
  ├─ Linux HANA Memory                                               Monthly cost depends on usage: $0.0031 per Memory hours 
  ├─ Linux HANA Cores                                                Monthly cost depends on usage: $0.44 per Core hours     
- └─ Linux HANA OS for SLES                                          Monthly cost depends on usage: $0.68 per Instance hours 
+ └─ Linux HANA OS for SLES (first 1 Instance hours)                 Monthly cost depends on usage: $0.34 per Instance hours 
+ └─ Linux HANA OS for SLES (next 2 Instance hours)                  Monthly cost depends on usage: $0.68 per Instance hours 
+ └─ Linux HANA OS for SLES (over 3 Instance hours)                  Monthly cost depends on usage: $0.82 per Instance hours 
                                                                                                                             
  ibm_pi_instance.ibmi-dedicated-e980-instance                                                                               
  ├─ Storage - tier1                                                            14,600  GB hours                       $4.00 
@@ -41,24 +45,20 @@
                                                                                                                             
  ibm_pi_instance.netweaver-shared-s922-instance                                                                             
  ├─ Storage - tier1                                                            14,600  GB hours                       $4.00 
- ├─ Cores                                                                         730  Core hours                    $92.23 
- ├─ Memory                                                                        730  GB hours                       $8.70 
- └─ Image cost (Licence Fee) for SLES (first 1 GB hours)                            1  GB hours                       $0.10 
- └─ Image cost (Licence Fee) for SLES (next 2 GB hours)                             2  GB hours                       $0.20 
- └─ Image cost (Licence Fee) for SLES (over 3 GB hours)                             2  GB hours                       $0.40 
+ └─ Linux NETWEAVER OS for SLES (first 1 Instance hours)                            1  Instance hours                 $0.34 
+ └─ Linux NETWEAVER OS for SLES (next 2 Instance hours)                             2  Instance hours                 $1.36 
+ └─ Linux NETWEAVER OS for SLES (over 3 Instance hours)                             2  Instance hours                 $1.64 
                                                                                                                             
  ibm_pi_instance.netweaver-shared-s922-no-usage-specified-instance                                                          
  ├─ Storage - tier1                                                 Monthly cost depends on usage: $0.000274 per GB hours   
- ├─ Cores                                                           Monthly cost depends on usage: $0.13 per Core hours     
- ├─ Memory                                                          Monthly cost depends on usage: $0.011913 per GB hours   
- └─ Image cost (Licence Fee) for SLES (first 1 GB hours)            Monthly cost depends on usage: $0.10 per GB hours       
- └─ Image cost (Licence Fee) for SLES (next 2 GB hours)             Monthly cost depends on usage: $0.10 per GB hours       
- └─ Image cost (Licence Fee) for SLES (over 3 GB hours)             Monthly cost depends on usage: $0.20 per GB hours       
+ └─ Linux NETWEAVER OS for SLES (first 1 Instance hours)            Monthly cost depends on usage: $0.34 per Instance hours 
+ └─ Linux NETWEAVER OS for SLES (next 2 Instance hours)             Monthly cost depends on usage: $0.68 per Instance hours 
+ └─ Linux NETWEAVER OS for SLES (over 3 Instance hours)             Monthly cost depends on usage: $0.82 per Instance hours 
                                                                                                                             
  ibm_resource_instance.powervs_service                                                                                      
  └─ Workspace for Power Virtual Server                                              1  Workspace                      $0.00 
                                                                                                                             
- OVERALL TOTAL                                                                                                    $6,530.12 
+ OVERALL TOTAL                                                                                                    $5,938.78 
 ──────────────────────────────────
 14 cloud resources were detected:
 ∙ 8 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/ibm/testdata/pi_instance_test/pi_instance_test.golden
+++ b/internal/providers/terraform/ibm/testdata/pi_instance_test/pi_instance_test.golden
@@ -45,12 +45,16 @@
                                                                                                                             
  ibm_pi_instance.netweaver-shared-s922-instance                                                                             
  ├─ Storage - tier1                                                            14,600  GB hours                       $4.00 
+ ├─ Cores                                                                         730  Core hours                    $92.23 
+ ├─ Memory                                                                        730  GB hours                       $8.70 
  └─ Linux NETWEAVER OS for SLES (first 1 Instance hours)                            1  Instance hours                 $0.34 
  └─ Linux NETWEAVER OS for SLES (next 2 Instance hours)                             2  Instance hours                 $1.36 
  └─ Linux NETWEAVER OS for SLES (over 3 Instance hours)                             2  Instance hours                 $1.64 
                                                                                                                             
  ibm_pi_instance.netweaver-shared-s922-no-usage-specified-instance                                                          
  ├─ Storage - tier1                                                 Monthly cost depends on usage: $0.000274 per GB hours   
+ ├─ Cores                                                           Monthly cost depends on usage: $0.13 per Core hours     
+ ├─ Memory                                                          Monthly cost depends on usage: $0.011913 per GB hours   
  └─ Linux NETWEAVER OS for SLES (first 1 Instance hours)            Monthly cost depends on usage: $0.34 per Instance hours 
  └─ Linux NETWEAVER OS for SLES (next 2 Instance hours)             Monthly cost depends on usage: $0.68 per Instance hours 
  └─ Linux NETWEAVER OS for SLES (over 3 Instance hours)             Monthly cost depends on usage: $0.82 per Instance hours 
@@ -58,7 +62,7 @@
  ibm_resource_instance.powervs_service                                                                                      
  └─ Workspace for Power Virtual Server                                              1  Workspace                      $0.00 
                                                                                                                             
- OVERALL TOTAL                                                                                                    $5,938.78 
+ OVERALL TOTAL                                                                                                    $6,039.70 
 ──────────────────────────────────
 14 cloud resources were detected:
 ∙ 8 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/resources/ibm/pi_instance.go
+++ b/internal/resources/ibm/pi_instance.go
@@ -352,10 +352,10 @@ func (r *PiInstance) piInstanceOSHanaProfileCostComponent() *schema.CostComponen
 	}
 
 	if r.OperatingSystem == SLES {
-		unit = "SUSE_OS_SAP_TIER_TWO_INSTANCE_HOURS"
+		unit = "SUSE_SAP_LICENSE_PER_COR_HOUR"
 		nameString = "Linux HANA OS for SLES"
 	} else if r.OperatingSystem == RHEL {
-		unit = "OS_LICENSE_CORE_HOUR"
+		unit = "REDHAT_SAP_SCALE_UP_LICENSE_PER_CORE_HOUR"
 		nameString = "Linux HANA OS for RHEL"
 	}
 

--- a/internal/resources/ibm/pi_instance.go
+++ b/internal/resources/ibm/pi_instance.go
@@ -78,13 +78,13 @@ func (r *PiInstance) BuildResource() *schema.Resource {
 
 	if r.Profile != "" {
 		costComponents = append(costComponents, r.piInstanceMemoryHanaProfileCostComponent(), r.piInstanceCoresHanaProfileCostComponent(), r.piInstanceOSHanaProfileCostComponent())
-	} else if r.NetweaverImage {
-		costComponents = append(costComponents, r.piInstanceNetweaverImageCostComponent())
 	} else {
 		costComponents = append(costComponents, r.piInstanceCoresCostComponent(), r.piInstanceMemoryCostComponent())
 
 		if r.OperatingSystem == AIX {
 			costComponents = append(costComponents, r.piInstanceAIXOperatingSystemCostComponent())
+		} else if r.NetweaverImage {
+			costComponents = append(costComponents, r.piInstanceNetweaverImageCostComponent())
 		} else if r.OperatingSystem == IBMI {
 			costComponents = append(costComponents,
 				r.piInstanceIBMiLPPPOperatingSystemCostComponent(),


### PR DESCRIPTION
Fix for issue here: https://github.ibm.com/orgs/cloud-finops/projects/3/views/1?pane=issue&itemId=1327993&issue=cloud-finops%7Cissues%7C452

Multiple issues with pi_instance resource including image name not being set properly, missing support for s1022 chip, missing cost component function to handle image cost for RHEL and SLES in some cases, missing logic in Linux Hana os cost component to check image type for SLES or RHEL