### PR TITLE
Fix Go GitHub Actions workflow so that all jobs pass + add cost support for is_instance custom image

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - errcheck
     - gocritic
     - gofmt
@@ -13,10 +12,8 @@ linters:
     - misspell
     - revive
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
 
 linters-settings:
   gocritic:

--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -2,7 +2,7 @@ package main_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -206,7 +206,7 @@ func TestBreakdownTerraformOutFileHTML(t *testing.T) {
 
 	GoldenFileCommandTest(t, testdataName, []string{"breakdown", "--path", "./testdata/example_plan.json", "--format", "html", "--out-file", outputPath}, nil)
 
-	actual, err := ioutil.ReadFile(outputPath)
+	actual, err := os.ReadFile(outputPath)
 	require.Nil(t, err)
 	actual = stripDynamicValues(actual)
 
@@ -220,7 +220,7 @@ func TestBreakdownTerraformOutFileJSON(t *testing.T) {
 
 	GoldenFileCommandTest(t, testdataName, []string{"breakdown", "--path", "./testdata/example_plan.json", "--format", "json", "--out-file", outputPath}, nil)
 
-	actual, err := ioutil.ReadFile(outputPath)
+	actual, err := os.ReadFile(outputPath)
 	require.Nil(t, err)
 	actual = stripDynamicValues(actual)
 
@@ -234,7 +234,7 @@ func TestBreakdownTerraformOutFileTable(t *testing.T) {
 
 	GoldenFileCommandTest(t, testdataName, []string{"breakdown", "--path", "./testdata/example_plan.json", "--out-file", outputPath}, nil)
 
-	actual, err := ioutil.ReadFile(outputPath)
+	actual, err := os.ReadFile(outputPath)
 	require.Nil(t, err)
 	actual = stripDynamicValues(actual)
 
@@ -248,7 +248,7 @@ func TestBreakdownTerraformSyncUsageFile(t *testing.T) {
 
 	GoldenFileCommandTest(t, testdataName, []string{"breakdown", "--path", "testdata/breakdown_terraform_sync_usage_file/sync_usage_file.json", "--usage-file", usageFilePath, "--sync-usage-file"}, nil)
 
-	actual, err := ioutil.ReadFile(usageFilePath)
+	actual, err := os.ReadFile(usageFilePath)
 	require.Nil(t, err)
 	actual = stripDynamicValues(actual)
 
@@ -423,7 +423,7 @@ func TestBreakdownWithWorkspace(t *testing.T) {
 
 func TestBreakdownWithActualCosts(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		bodyBytes, _ := ioutil.ReadAll(r.Body)
+		bodyBytes, _ := io.ReadAll(r.Body)
 		graphqlQuery := string(bodyBytes)
 
 		if strings.Contains(graphqlQuery, "actualCostsList") {

--- a/cmd/infracost/comment.go
+++ b/cmd/infracost/comment.go
@@ -64,7 +64,7 @@ func buildCommentBody(cmd *cobra.Command, ctx *config.RunContext, paths []string
 
 	combined, err := output.Combine(inputs)
 	if errors.As(err, &clierror.WarningError{}) {
-		ui.PrintWarningf(cmd.ErrOrStderr(), err.Error())
+		ui.PrintWarningf(cmd.ErrOrStderr(), "%s", err.Error())
 	} else if err != nil {
 		return nil, hasDiff, err
 	}

--- a/cmd/infracost/comment_github_test.go
+++ b/cmd/infracost/comment_github_test.go
@@ -3,7 +3,7 @@ package main_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -340,7 +340,7 @@ type guardrailEvent struct {
 
 func guardrailTestEndpoint(gr guardrailAddRunResponse) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		bodyBytes, _ := ioutil.ReadAll(r.Body)
+		bodyBytes, _ := io.ReadAll(r.Body)
 		graphqlQuery := string(bodyBytes)
 
 		if strings.Contains(graphqlQuery, "mutation($run: RunInput!)") {

--- a/cmd/infracost/diff_test.go
+++ b/cmd/infracost/diff_test.go
@@ -2,7 +2,6 @@ package main_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -36,7 +35,7 @@ func TestDiffTerraformOutFile(t *testing.T) {
 
 	GoldenFileCommandTest(t, testdataName, []string{"diff", "--path", "./testdata/example_plan.json", "--out-file", outputPath}, nil)
 
-	actual, err := ioutil.ReadFile(outputPath)
+	actual, err := os.ReadFile(outputPath)
 	require.Nil(t, err)
 	actual = stripDynamicValues(actual)
 
@@ -131,7 +130,7 @@ projects:
 		path.Join(dir, "prod"))
 
 	configFilePath := path.Join(dir, "infracost.yml")
-	err := os.WriteFile(configFilePath, []byte(configFile), os.ModePerm)
+	err := os.WriteFile(configFilePath, []byte(configFile), os.ModePerm) //nolint:gosec
 	require.NoError(t, err)
 
 	defer os.Remove(configFilePath)
@@ -158,7 +157,7 @@ projects:
 		path.Join(dir, "prod"))
 
 	configFilePath := path.Join(dir, "infracost.yml")
-	err := os.WriteFile(configFilePath, []byte(configFile), os.ModePerm)
+	err := os.WriteFile(configFilePath, []byte(configFile), os.ModePerm) //nolint:gosec
 	require.NoError(t, err)
 
 	defer os.Remove(configFilePath)

--- a/cmd/infracost/main.go
+++ b/cmd/infracost/main.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	stdLog "log"
 	"os"
 	"runtime/debug"
@@ -27,7 +27,7 @@ import (
 func init() {
 	// set the stdlib default logger to flush to discard, this is done as a number of
 	// Terraform libs use the std logger directly, which impacts Infracost output.
-	stdLog.SetOutput(ioutil.Discard)
+	stdLog.SetOutput(io.Discard)
 }
 
 func main() {
@@ -354,7 +354,7 @@ func saveOutFile(ctx *config.RunContext, cmd *cobra.Command, outFile string, b [
 
 // saveOutFile saves the output of the command to the file path past in the `--out-file` flag
 func saveOutFileWithMsg(ctx *config.RunContext, cmd *cobra.Command, outFile, successMsg string, b []byte) error {
-	err := ioutil.WriteFile(outFile, b, 0644) // nolint:gosec
+	err := os.WriteFile(outFile, b, 0644) // nolint:gosec
 	if err != nil {
 		return errors.Wrap(err, "Unable to save output")
 	}

--- a/cmd/infracost/output.go
+++ b/cmd/infracost/output.go
@@ -96,7 +96,7 @@ func outputCmd(ctx *config.RunContext) *cobra.Command {
 			combined, err := output.Combine(inputs)
 			if errors.As(err, &clierror.WarningError{}) {
 				if format == "json" {
-					ui.PrintWarningf(cmd.ErrOrStderr(), err.Error())
+					ui.PrintWarningf(cmd.ErrOrStderr(), "%s", err.Error())
 				}
 			} else if err != nil {
 				return err

--- a/cmd/infracost/output_test.go
+++ b/cmd/infracost/output_test.go
@@ -1,7 +1,7 @@
 package main_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"testing"
@@ -140,7 +140,7 @@ func TestOutputTerraformOutFileHTML(t *testing.T) {
 
 	GoldenFileCommandTest(t, testdataName, []string{"output", "--path", "./testdata/example_out.json", "--format", "html", "--out-file", outputPath}, nil)
 
-	actual, err := ioutil.ReadFile(outputPath)
+	actual, err := os.ReadFile(outputPath)
 	require.Nil(t, err)
 	actual = stripDynamicValues(actual)
 
@@ -154,7 +154,7 @@ func TestOutputTerraformOutFileJSON(t *testing.T) {
 
 	GoldenFileCommandTest(t, testdataName, []string{"output", "--path", "./testdata/example_out.json", "--format", "json", "--out-file", outputPath}, nil)
 
-	actual, err := ioutil.ReadFile(outputPath)
+	actual, err := os.ReadFile(outputPath)
 	require.Nil(t, err)
 	actual = stripDynamicValues(actual)
 
@@ -168,7 +168,7 @@ func TestOutputTerraformOutFileTable(t *testing.T) {
 
 	GoldenFileCommandTest(t, testdataName, []string{"output", "--path", "./testdata/example_out.json", "--out-file", outputPath}, nil)
 
-	actual, err := ioutil.ReadFile(outputPath)
+	actual, err := os.ReadFile(outputPath)
 	require.Nil(t, err)
 	actual = stripDynamicValues(actual)
 

--- a/cmd/infracost/register.go
+++ b/cmd/infracost/register.go
@@ -1,37 +1,39 @@
 package main
 
-import (
-	"github.com/spf13/cobra"
+// As of 03,07,2025, commenting out because function is unused in cmd/infracost/main.go
 
-	"github.com/infracost/infracost/internal/config"
-	"github.com/infracost/infracost/internal/ui"
-)
+// import (
+// 	"github.com/spf13/cobra"
 
-func registerCmd(ctx *config.RunContext) *cobra.Command {
-	login := authLoginCmd(ctx)
-	cmd := &cobra.Command{
-		Use:    "register",
-		Hidden: true,
-		Short:  login.Short,
-		Long:   login.Long,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			ui.PrintWarningf(cmd.ErrOrStderr(),
-				"this command has been changed to %s, which does the same thing - we’ll run that for you now.\n",
-				ui.PrimaryString("infracost auth login"),
-			)
+// 	"github.com/infracost/infracost/internal/config"
+// 	"github.com/infracost/infracost/internal/ui"
+// )
 
-			return login.RunE(cmd, args)
-		},
-	}
+// func registerCmd(ctx *config.RunContext) *cobra.Command {
+// 	login := authLoginCmd(ctx)
+// 	cmd := &cobra.Command{
+// 		Use:    "register",
+// 		Hidden: true,
+// 		Short:  login.Short,
+// 		Long:   login.Long,
+// 		RunE: func(cmd *cobra.Command, args []string) error {
+// 			ui.PrintWarningf(cmd.ErrOrStderr(),
+// 				"this command has been changed to %s, which does the same thing - we’ll run that for you now.\n",
+// 				ui.PrimaryString("infracost auth login"),
+// 			)
 
-	cmd.SetHelpFunc(func(cmd *cobra.Command, strings []string) {
-		ui.PrintWarningf(cmd.ErrOrStderr(),
-			"this command has been changed to %s, which does the same thing - showing information for that command.\n",
-			ui.PrimaryString("infracost auth login"),
-		)
+// 			return login.RunE(cmd, args)
+// 		},
+// 	}
 
-		login.HelpFunc()(login, strings)
-	})
+// 	cmd.SetHelpFunc(func(cmd *cobra.Command, strings []string) {
+// 		ui.PrintWarningf(cmd.ErrOrStderr(),
+// 			"this command has been changed to %s, which does the same thing - showing information for that command.\n",
+// 			ui.PrimaryString("infracost auth login"),
+// 		)
 
-	return cmd
-}
+// 		login.HelpFunc()(login, strings)
+// 	})
+
+// 	return cmd
+// }

--- a/internal/apiclient/auth.go
+++ b/internal/apiclient/auth.go
@@ -65,18 +65,13 @@ func (a AuthClient) startCallbackServer(listener net.Listener, generatedState st
 	go func() {
 		defer close(shutdown)
 
-		for {
-			select {
-			case <-time.After(time.Minute * 5):
-				shutdown <- callbackServerResp{err: fmt.Errorf("timeout")}
-				listener.Close()
-				return
-			}
-		}
+		time.Sleep(time.Minute * 5)
+		shutdown <- callbackServerResp{err: fmt.Errorf("timeout")}
+		listener.Close()
 	}()
 
 	go func() {
-		_ = http.Serve(listener, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = http.Serve(listener, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { //nolint:gosec
 			if r.Method == http.MethodOptions {
 				return
 			}

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -96,7 +96,7 @@ func (c *APIClient) doRequest(method string, path string, d interface{}) ([]byte
 
 		err = json.Unmarshal(respBody, &r)
 		if err != nil {
-			return []byte{}, &APIError{fmt.Errorf(resp.Status), "Invalid API response"}
+			return []byte{}, &APIError{fmt.Errorf("%s", resp.Status), "Invalid API response"}
 		}
 
 		if r.Error == "Invalid API key" {

--- a/internal/apiclient/pricing.go
+++ b/internal/apiclient/pricing.go
@@ -44,7 +44,7 @@ func NewPricingAPIClient(ctx *config.RunContext) *PricingAPIClient {
 
 	tlsConfig := tls.Config{
 		MinVersion: tls.VersionTLS12,
-	} // nolint: gosec
+	} //nolint:gosec
 
 	if ctx.Config.TLSCACertFile != "" {
 		rootCAs, _ := x509.SystemCertPool()

--- a/internal/apiclient/usage.go
+++ b/internal/apiclient/usage.go
@@ -49,7 +49,7 @@ func NewUsageAPIClient(ctx *config.RunContext) *UsageAPIClient {
 		currency = "USD"
 	}
 
-	tlsConfig := tls.Config{} // nolint: gosec
+	tlsConfig := tls.Config{} //nolint:gosec
 
 	if ctx.Config.TLSCACertFile != "" {
 		rootCAs, _ := x509.SystemCertPool()
@@ -74,7 +74,7 @@ func NewUsageAPIClient(ctx *config.RunContext) *UsageAPIClient {
 	}
 
 	if ctx.Config.TLSInsecureSkipVerify != nil {
-		tlsConfig.InsecureSkipVerify = *ctx.Config.TLSInsecureSkipVerify
+		tlsConfig.InsecureSkipVerify = *ctx.Config.TLSInsecureSkipVerify //nolint:gosec
 	}
 
 	return &UsageAPIClient{

--- a/internal/clierror/error.go
+++ b/internal/clierror/error.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/maruel/panicparse/v2/stack"
 	log "github.com/sirupsen/logrus"
@@ -82,7 +81,7 @@ func processStack(rawStack []byte) ([]byte, error) {
 	var buf bytes.Buffer
 	w := bufio.NewWriter(&buf)
 
-	s, suffix, err := stack.ScanSnapshot(stream, ioutil.Discard, stack.DefaultOpts())
+	s, suffix, err := stack.ScanSnapshot(stream, io.Discard, stack.DefaultOpts())
 	if err != nil && err != io.EOF {
 		return []byte{}, err
 	}

--- a/internal/comment/azure_repos.go
+++ b/internal/comment/azure_repos.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -183,7 +183,7 @@ func (h *azureReposPRHandler) CallFindMatchingComments(ctx context.Context, tag 
 		defer res.Body.Close()
 	}
 
-	resBody, err := ioutil.ReadAll(res.Body)
+	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		return []Comment{}, errors.Wrap(err, "Error reading response body")
 	}
@@ -265,7 +265,7 @@ func (h *azureReposPRHandler) CallCreateComment(ctx context.Context, body string
 		defer res.Body.Close()
 	}
 
-	resBody, err := ioutil.ReadAll(res.Body)
+	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error reading response body")
 	}

--- a/internal/comment/bitbucket.go
+++ b/internal/comment/bitbucket.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"net/http"
 	"strconv"
@@ -193,7 +193,7 @@ func (h *bitbucketPRHandler) CallFindMatchingComments(ctx context.Context, tag s
 			defer res.Body.Close()
 		}
 
-		resBody, err := ioutil.ReadAll(res.Body)
+		resBody, err := io.ReadAll(res.Body)
 		if err != nil {
 			return []Comment{}, errors.Wrap(err, "Error reading response body")
 		}
@@ -263,7 +263,7 @@ func (h *bitbucketPRHandler) CallCreateComment(ctx context.Context, body string)
 		defer res.Body.Close()
 	}
 
-	resBody, err := ioutil.ReadAll(res.Body)
+	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error reading response body")
 	}
@@ -398,7 +398,7 @@ func (h *bitbucketCommitHandler) CallFindMatchingComments(ctx context.Context, t
 			defer res.Body.Close()
 		}
 
-		resBody, err := ioutil.ReadAll(res.Body)
+		resBody, err := io.ReadAll(res.Body)
 		if err != nil {
 			return []Comment{}, errors.Wrap(err, "Error reading response body")
 		}
@@ -468,7 +468,7 @@ func (h *bitbucketCommitHandler) CallCreateComment(ctx context.Context, body str
 		defer res.Body.Close()
 	}
 
-	resBody, err := ioutil.ReadAll(res.Body)
+	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error reading response body")
 	}
@@ -609,7 +609,7 @@ func (h *bitbucketServerPRHandler) CallFindMatchingComments(ctx context.Context,
 			defer res.Body.Close()
 		}
 
-		resBody, err := ioutil.ReadAll(res.Body)
+		resBody, err := io.ReadAll(res.Body)
 		if err != nil {
 			return []Comment{}, errors.Wrap(err, "Error reading response body")
 		}
@@ -680,7 +680,7 @@ func (h *bitbucketServerPRHandler) CallCreateComment(ctx context.Context, body s
 		defer res.Body.Close()
 	}
 
-	resBody, err := ioutil.ReadAll(res.Body)
+	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error reading response body")
 	}
@@ -782,7 +782,7 @@ func (h *bitbucketServerPRHandler) fetchServerComment(commentURL string) (*bitbu
 	if res.Body != nil {
 		defer res.Body.Close()
 	}
-	resBody, err := ioutil.ReadAll(res.Body)
+	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error reading response body")
 	}

--- a/internal/comment/github.go
+++ b/internal/comment/github.go
@@ -188,8 +188,8 @@ func (h *githubPRHandler) CallFindMatchingComments(ctx context.Context, tag stri
 	variables := map[string]interface{}{
 		"owner":    githubv4.String(h.owner),
 		"repo":     githubv4.String(h.repo),
-		"prNumber": githubv4.Int(h.prNumber),
-		"after":    (*githubv4.String)(nil), // Null after argument to get first page.
+		"prNumber": githubv4.Int(h.prNumber), //nolint:gosec // ignore G115: integer overflow conversion int -> int32
+		"after":    (*githubv4.String)(nil),  // Null after argument to get first page.
 	}
 
 	// Get comments from all pages.

--- a/internal/comment/gitlab.go
+++ b/internal/comment/gitlab.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -217,7 +217,7 @@ func (h *gitlabPRHandler) CallCreateComment(ctx context.Context, body string) (C
 		defer res.Body.Close()
 	}
 
-	resBody, err := ioutil.ReadAll(res.Body)
+	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error reading response body")
 	}
@@ -367,7 +367,7 @@ func (h *gitlabCommitHandler) CallFindMatchingComments(ctx context.Context, tag 
 			defer res.Body.Close()
 		}
 
-		resBody, err := ioutil.ReadAll(res.Body)
+		resBody, err := io.ReadAll(res.Body)
 		if err != nil {
 			return []Comment{}, errors.Wrap(err, "Error reading response body")
 		}
@@ -451,7 +451,7 @@ func (h *gitlabCommitHandler) CallCreateComment(ctx context.Context, body string
 		defer res.Body.Close()
 	}
 
-	resBody, err := ioutil.ReadAll(res.Body)
+	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error reading response body")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -106,7 +106,7 @@ projects:
 		t.Run(tt.name, func(t *testing.T) {
 			c := Config{}
 			path := filepath.Join(tmp, fmt.Sprintf("conf-%d.yaml", i))
-			err := os.WriteFile(path, tt.contents, os.ModePerm)
+			err := os.WriteFile(path, tt.contents, os.ModePerm) //nolint:gosec
 			require.NoError(t, err)
 
 			// we need to remove INFRACOST_TERRAFORM_CLOUD_TOKEN value for these tests.

--- a/internal/hcl/attribute.go
+++ b/internal/hcl/attribute.go
@@ -626,8 +626,6 @@ func (attr *Attribute) findBadVariablesFromExpression(expression hcl.Expression)
 					badVars = append(badVars, traversal)
 					return badVars
 				}
-
-				break
 			}
 
 			return attr.findBadVariables(s.Collection.Variables())

--- a/internal/hcl/funcs/collection.go
+++ b/internal/hcl/funcs/collection.go
@@ -501,7 +501,7 @@ var SumFunc = function.New(&function.Spec{
 		ty := args[0].Type()
 
 		if !ty.IsListType() && !ty.IsSetType() && !ty.IsTupleType() {
-			return cty.NilVal, function.NewArgErrorf(0, fmt.Sprintf("argument must be list, set, or tuple. Received %s", ty.FriendlyName()))
+			return cty.NilVal, function.NewArgErrorf(0, "%s", fmt.Sprintf("argument must be list, set, or tuple. Received %s", ty.FriendlyName()))
 		}
 
 		if !args[0].IsWhollyKnown() {

--- a/internal/hcl/funcs/crypto.go
+++ b/internal/hcl/funcs/crypto.go
@@ -168,7 +168,7 @@ var RsaDecryptFunc = function.New(&function.Spec{
 			default:
 				errStr = fmt.Sprintf("invalid private key: %s", e)
 			}
-			return cty.UnknownVal(cty.String), function.NewArgErrorf(1, errStr)
+			return cty.UnknownVal(cty.String), function.NewArgErrorf(1, "%s", errStr)
 		}
 		privateKey, ok := rawKey.(*rsa.PrivateKey)
 		if !ok {

--- a/internal/hcl/funcs/crypto_test.go
+++ b/internal/hcl/funcs/crypto_test.go
@@ -678,6 +678,7 @@ func TestFileSHA512(t *testing.T) {
 	}
 }
 
+// nolint:gosec
 const (
 	CipherBase64 = "eczGaDhXDbOFRZGhjx2etVzWbRqWDlmq0bvNt284JHVbwCgObiuyX9uV0LSAMY707IEgMkExJqXmsB4OWKxvB7epRB9G/3+F+pcrQpODlDuL9oDUAsa65zEpYF0Wbn7Oh7nrMQncyUPpyr9WUlALl0gRWytOA23S+y5joa4M34KFpawFgoqTu/2EEH4Xl1zo+0fy73fEto+nfkUY+meuyGZ1nUx/+DljP7ZqxHBFSlLODmtuTMdswUbHbXbWneW51D7Jm7xB8nSdiA2JQNK5+Sg5x8aNfgvFTt/m2w2+qpsyFa5Wjeu6fZmXSl840CA07aXbk9vN4I81WmJyblD/ZA=="
 	PrivateKey   = `
@@ -708,7 +709,7 @@ OLlRAoGBAIZ5Uv4Z3s8O7WKXXUe/lq6j7vfiVkR1NW/Z/WLKXZpnmvJ7FgxN4e56
 RXT7GwNQHIY8eDjDnsHxzrxd+raOxOZeKcMHj3XyjCX3NHfTscnsBPAGYpY/Wxzh
 T8UYnFu6RzkixElTf2rseEav7rkdKkI3LAeIZy7B0HulKKsmqVQ7
 -----END RSA PRIVATE KEY-----
-`
+` //nolint:gosec
 	OpenSSHPrivateKey = `
 -----BEGIN OPENSSH PRIVATE KEY-----
 b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABFwAAAAdzc2gtcn
@@ -737,7 +738,7 @@ dA6CXZVPS1nq6V3Gs5SXCHTs/0vUA5kit0Q0E3an08UZq8YmCPSxLJpDpL85Z5zgTKZ2d2
 TlOaiEX6a3nESIt+ygwDh1hp5QtBFhoJeOmC2+/414ln9ABmPg3ySTXfYuk2yA1rvNueP3
 qwEumyjIVv96u39pAAAAAAEC
 -----END OPENSSH PRIVATE KEY-----
-`
+` //nolint:gosec
 	WrongPrivateKey = `
 -----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEAlrCgnEVgmNKCq7KPc+zUU5IrxPu1ClMNJS7RTsTPEkbwe5SB
@@ -766,7 +767,7 @@ CYhwNQKBgGPcLXmjpGtkZvggl0aZr9LsvCTckllSCFSI861kivL/rijdNoCHGxZv
 dfDkLTLcz9Gk41rD9Gxn/3sqodnTAc3Z2PxFnzg1Q/u3+x6YAgBwI/g/jE2xutGW
 H7CurtMwALQ/n/6LUKFmjRZjqbKX9SO2QSaC3grd6sY9Tu+bZjLe
 -----END RSA PRIVATE KEY-----
-`
+` //nolint:gosec
 	BadPrivateKey = `
 -----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEAgUElV5mwqkloIrM8ZNZ72gSCcnSJt7+/Usa5G+D15YQUAdf9
@@ -794,5 +795,5 @@ OLlRAoGBAIZ5Uv4Z3s8O7WKXXUe/lq6j7vfiVkR1NW/Z/WLKXZpnmvJ7FgxN4e56
 RXT7GwNQHIY8eDjDnsHxzrxd+raOxOZeKcMHj3XyjCX3NHfTscnsBPAGYpY/Wxzh
 T8UYnFu6RzkixElTf2rseEav7rkdKkI3LAeIZy7B0HulKKsmqVQ7
 -----END RSA PRIVATE KEY-----
-`
+` //nolint:gosec
 )

--- a/internal/hcl/funcs/filesystem.go
+++ b/internal/hcl/funcs/filesystem.go
@@ -3,7 +3,7 @@ package funcs
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"unicode/utf8"
@@ -378,7 +378,7 @@ func readFileBytes(baseDir, path string) ([]byte, error) {
 		return nil, err
 	}
 
-	src, err := ioutil.ReadAll(f)
+	src, err := io.ReadAll(f)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s", path)
 	}

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -198,7 +198,6 @@ type Parser struct {
 	blockBuilder          BlockBuilder
 	newSpinner            ui.SpinnerFunc
 	remoteVariablesLoader *RemoteVariablesLoader
-	credentialsSource     *modules.CredentialsSource
 	logger                *logrus.Entry
 	hasChanges            bool
 }

--- a/internal/hcl/parser_test.go
+++ b/internal/hcl/parser_test.go
@@ -2,7 +2,6 @@ package hcl
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -731,19 +730,19 @@ func TestOptionWithRawCtyInput(t *testing.T) {
 }
 
 func createTestFile(filename, contents string) string {
-	dir, err := ioutil.TempDir(os.TempDir(), "infracost")
+	dir, err := os.MkdirTemp(os.TempDir(), "infracost")
 	if err != nil {
 		panic(err)
 	}
 	path := filepath.Join(dir, filename)
-	if err := os.WriteFile(path, []byte(contents), os.ModePerm); err != nil {
+	if err := os.WriteFile(path, []byte(contents), os.ModePerm); err != nil { //nolint:gosec
 		panic(err)
 	}
 	return path
 }
 
 func createTestFileWithModule(contents string, moduleContents string, moduleName string) string {
-	dir, err := ioutil.TempDir(os.TempDir(), "infracost")
+	dir, err := os.MkdirTemp(os.TempDir(), "infracost")
 	if err != nil {
 		panic(err)
 	}
@@ -764,11 +763,11 @@ func createTestFileWithModule(contents string, moduleContents string, moduleName
 		}
 	}
 
-	if err := os.WriteFile(filepath.Join(rootPath, "main.tf"), []byte(contents), os.ModePerm); err != nil {
+	if err := os.WriteFile(filepath.Join(rootPath, "main.tf"), []byte(contents), os.ModePerm); err != nil { //nolint:gosec
 		panic(err)
 	}
 
-	if err := os.WriteFile(filepath.Join(modulePath, "main.tf"), []byte(moduleContents), os.ModePerm); err != nil {
+	if err := os.WriteFile(filepath.Join(modulePath, "main.tf"), []byte(moduleContents), os.ModePerm); err != nil { //nolint:gosec
 		panic(err)
 	}
 

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -78,7 +78,7 @@ type scaledInt64 struct {
 // length of the fraction.
 func decimalToScaledInt(d decimal.Decimal, minFracLen, maxFracLen int) *scaledInt64 {
 	// round excess fraction part
-	d = d.Round(int32(maxFracLen))
+	d = d.Round(int32(maxFracLen)) // nolint:gosec
 
 	co := d.Coefficient().Int64()
 	ex := int(d.Exponent())

--- a/internal/output/format_test.go
+++ b/internal/output/format_test.go
@@ -41,7 +41,7 @@ func TestFormatCost(t *testing.T) {
 
 			diff := cmp.Diff(tc.expected, got)
 			if diff != "" {
-				t.Fatalf(diff)
+				t.Fatalf("%s", diff)
 			}
 		})
 	}
@@ -78,7 +78,7 @@ func TestFormatCost2DP(t *testing.T) {
 
 			diff := cmp.Diff(tc.expected, got)
 			if diff != "" {
-				t.Fatalf(diff)
+				t.Fatalf("%s", diff)
 			}
 		})
 	}
@@ -121,7 +121,7 @@ func TestCurrencyFormatCost(t *testing.T) {
 
 			diff := cmp.Diff(tc.expected, got)
 			if diff != "" {
-				t.Fatalf(diff)
+				t.Fatalf("%s", diff)
 			}
 		})
 	}
@@ -161,7 +161,7 @@ func TestFormatPrice(t *testing.T) {
 
 			diff := cmp.Diff(tc.expected, got)
 			if diff != "" {
-				t.Fatalf(diff)
+				t.Fatalf("%s", diff)
 			}
 		})
 	}

--- a/internal/providers/terraform/azure/mssql_database.go
+++ b/internal/providers/terraform/azure/mssql_database.go
@@ -92,7 +92,7 @@ func newAzureRMMSSQLDatabase(d *schema.ResourceData, u *schema.UsageData) *schem
 	if !dtuMap.usesDTUUnits(sku) {
 		c, err := parseMSSQLSku(d.Address, sku)
 		if err != nil {
-			log.Warnf(err.Error())
+			log.Warnf("%s", err.Error())
 			return nil
 		}
 

--- a/internal/providers/terraform/azure/sql_database.go
+++ b/internal/providers/terraform/azure/sql_database.go
@@ -79,7 +79,7 @@ func newSQLDatabase(d *schema.ResourceData, u *schema.UsageData) *schema.Resourc
 		var err error
 		config, err = parseSKU(d.Address, sku)
 		if err != nil {
-			log.Warnf(err.Error())
+			log.Warnf("%s", err.Error())
 			return nil
 		}
 	}

--- a/internal/providers/terraform/dir_provider.go
+++ b/internal/providers/terraform/dir_provider.go
@@ -93,13 +93,13 @@ func (p *DirProvider) checks() error {
 		msg := fmt.Sprintf("Terraform binary '%s' could not be found. You have two options:\n", binary)
 		msg += "1. Set a custom Terraform binary using the environment variable INFRACOST_TERRAFORM_BINARY.\n\n"
 		msg += fmt.Sprintf("2. Set --path to a Terraform plan JSON file. See %s for how to generate this.", ui.LinkString("https://infracost.io/troubleshoot"))
-		return clierror.NewCLIError(errors.Errorf(msg), "Terraform binary could not be found")
+		return clierror.NewCLIError(errors.Errorf("%s", msg), "Terraform binary could not be found")
 	}
 
 	out, err := exec.Command(binary, "-version").Output()
 	if err != nil {
 		msg := fmt.Sprintf("Could not get version of Terraform binary '%s'", binary)
-		return clierror.NewCLIError(errors.Errorf(msg), "Could not get version of Terraform binary")
+		return clierror.NewCLIError(errors.Errorf("%s", msg), "Could not get version of Terraform binary")
 	}
 
 	fullVersion := strings.SplitN(string(out), "\n", 2)[0]

--- a/internal/providers/terraform/ibm/testdata/ibm_cos_bucket_test/ibm_cos_bucket_test.golden
+++ b/internal/providers/terraform/ibm/testdata/ibm_cos_bucket_test/ibm_cos_bucket_test.golden
@@ -40,7 +40,11 @@
  └─ Lite Plan Bucket                                           1  Instance                         $0.00 
                                                                                                          
  ibm_cos_bucket.one-rate-us-south                                                                        
- ├─ Storage Capacity                          Monthly cost depends on usage: $0.0418 per GB              
+ ├─ Storage Capacity (first 1 GB)             Monthly cost depends on usage: $0.0418 per GB              
+ ├─ Storage Capacity (next 49999 GB)          Monthly cost depends on usage: $0.02 per GB                
+ ├─ Storage Capacity (next 150000 GB)         Monthly cost depends on usage: $0.017 per GB               
+ ├─ Storage Capacity (next 300000 GB)         Monthly cost depends on usage: $0.015 per GB               
+ ├─ Storage Capacity (over 499999 GB)         Monthly cost depends on usage: $0.012 per GB               
  ├─ Free Class A requests                     Monthly cost depends on usage: $0.00 per 1k API calls      
  ├─ Class A requests                          Monthly cost depends on usage: $0.005225 per 1k API calls  
  ├─ Free Class B requests                     Monthly cost depends on usage: $0.00 per 10k API calls     
@@ -49,7 +53,11 @@
  └─ Public Egress                             Monthly cost depends on usage: $0.05 per GB                
                                                                                                          
  ibm_cos_bucket.one-rate-us-south-usage                                                                  
- ├─ Storage Capacity                                       1,000  GB                              $41.80 
+ ├─ Storage Capacity (first 1 GB)                              1  GB                               $0.04 
+ ├─ Storage Capacity (next 49999 GB)                       1,000  GB                              $20.00 
+ ├─ Storage Capacity (next 150000 GB)                          0  GB                               $0.00 
+ ├─ Storage Capacity (next 300000 GB)                          0  GB                               $0.00 
+ ├─ Storage Capacity (over 499999 GB)                          0  GB                               $0.00 
  ├─ Free Class A requests                                    100  1k API calls                     $0.00 
  ├─ Class A requests                                         900  1k API calls                     $4.70 
  ├─ Free Class B requests                                     10  10k API calls                    $0.00 
@@ -93,7 +101,7 @@
  └─ Public Standard Egress (next 100000 GB)                    0  GB                               $0.00 
  └─ Public Standard Egress (over 150000 GB)                    0  GB                               $0.00 
                                                                                                          
- OVERALL TOTAL                                                                                   $495.39 
+ OVERALL TOTAL                                                                                   $473.64 
 ──────────────────────────────────
 14 cloud resources were detected:
 ∙ 13 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/ibm/testdata/is_floating_ip_test/is_floating_ip_test.golden
+++ b/internal/providers/terraform/ibm/testdata/is_floating_ip_test/is_floating_ip_test.golden
@@ -7,7 +7,7 @@
  ibm_is_instance.testInstance                                                                       
  ├─ Instance Hours (bx2-2x8)                   Monthly cost depends on usage: $0.10 per Hours       
  ├─ Boot volume (Unnamed boot volume, 100 GB)  Monthly cost depends on usage: $0.00011495 per Hours 
- └─ Free Provided Image                                       1                               $0.00 
+ └─ Custom Image                                              1                               $0.00 
                                                                                                     
  ibm_is_vpc.testVpc                                                                                 
  ├─ VPC instance                                              1  Instance                     $0.00 

--- a/internal/providers/terraform/ibm/testdata/is_floating_ip_test/is_floating_ip_test.golden
+++ b/internal/providers/terraform/ibm/testdata/is_floating_ip_test/is_floating_ip_test.golden
@@ -6,7 +6,8 @@
                                                                                                     
  ibm_is_instance.testInstance                                                                       
  ├─ Instance Hours (bx2-2x8)                   Monthly cost depends on usage: $0.10 per Hours       
- └─ Boot volume (Unnamed boot volume, 100 GB)  Monthly cost depends on usage: $0.00011495 per Hours 
+ ├─ Boot volume (Unnamed boot volume, 100 GB)  Monthly cost depends on usage: $0.00011495 per Hours 
+ └─ Free Provided Image                                       1                               $0.00 
                                                                                                     
  ibm_is_vpc.testVpc                                                                                 
  ├─ VPC instance                                              1  Instance                     $0.00 

--- a/internal/providers/terraform/ibm/testdata/is_flow_log_test/is_flow_log_test.golden
+++ b/internal/providers/terraform/ibm/testdata/is_flow_log_test/is_flow_log_test.golden
@@ -28,7 +28,8 @@
                                                                                                                    
  ibm_is_instance.testIsInstance                                                                                    
  ├─ Instance Hours (bx2-2x8)                                  Monthly cost depends on usage: $0.10 per Hours       
- └─ Boot volume (Unnamed boot volume, 100 GB)                 Monthly cost depends on usage: $0.00011495 per Hours 
+ ├─ Boot volume (Unnamed boot volume, 100 GB)                 Monthly cost depends on usage: $0.00011495 per Hours 
+ └─ Free Provided Image                                                      1                               $0.00 
                                                                                                                    
  ibm_is_vpc.testVpc                                                                                                
  ├─ VPC instance                                                             1  Instance                     $0.00 

--- a/internal/providers/terraform/ibm/testdata/is_flow_log_test/is_flow_log_test.golden
+++ b/internal/providers/terraform/ibm/testdata/is_flow_log_test/is_flow_log_test.golden
@@ -29,7 +29,7 @@
  ibm_is_instance.testIsInstance                                                                                    
  ├─ Instance Hours (bx2-2x8)                                  Monthly cost depends on usage: $0.10 per Hours       
  ├─ Boot volume (Unnamed boot volume, 100 GB)                 Monthly cost depends on usage: $0.00011495 per Hours 
- └─ Free Provided Image                                                      1                               $0.00 
+ └─ Custom Image                                                             1                               $0.00 
                                                                                                                    
  ibm_is_vpc.testVpc                                                                                                
  ├─ VPC instance                                                             1  Instance                     $0.00 

--- a/internal/providers/terraform/ibm/testdata/is_flow_log_test/is_flow_log_test.tf
+++ b/internal/providers/terraform/ibm/testdata/is_flow_log_test/is_flow_log_test.tf
@@ -31,7 +31,6 @@ resource "ibm_is_ssh_key" "testSshKey" {
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR"
 }
 
-
 resource "ibm_is_instance" "testIsInstance" {
   name    = "test-is-instance"
   image   = ibm_is_image.testIsImage.id

--- a/internal/providers/terraform/tftest/tftest.go
+++ b/internal/providers/terraform/tftest/tftest.go
@@ -295,8 +295,7 @@ func loadResources(t *testing.T, pName string, tfProject TerraformProject, runCt
 
 	tfdir := createTerraformProject(t, tfProject)
 	runCtx.Config.RootPath = tfdir
-	var provider schema.Provider
-	provider = terraform.NewDirProvider(config.NewProjectContext(runCtx, &config.Project{
+	var provider = terraform.NewDirProvider(config.NewProjectContext(runCtx, &config.Project{
 		Path: tfdir,
 	}, log.Fields{}), false)
 
@@ -435,7 +434,7 @@ func copyInitCacheToPath(source, destination string) error {
 						return err
 					}
 
-					if err := os.WriteFile(destPath, srcData, os.ModePerm); err != nil {
+					if err := os.WriteFile(destPath, srcData, os.ModePerm); err != nil { //nolint:gosec
 						return err
 					}
 				}

--- a/internal/resources/aws/db_instance.go
+++ b/internal/resources/aws/db_instance.go
@@ -161,7 +161,7 @@ func (r *DBInstance) BuildResource() *schema.Resource {
 		}
 		priceFilter, err = resolver.PriceFilter()
 		if err != nil {
-			log.Warnf(err.Error())
+			log.Warnf("%s", err.Error())
 		}
 		purchaseOptionLabel = "reserved"
 	}

--- a/internal/resources/aws/ec2_host.go
+++ b/internal/resources/aws/ec2_host.go
@@ -51,7 +51,7 @@ func (r *EC2Host) BuildResource() *schema.Resource {
 		priceFilter, err = resolver.PriceFilter()
 
 		if err != nil {
-			log.Warnf(err.Error())
+			log.Warnf("%s", err.Error())
 		}
 
 		purchaseOptionLabel = "reserved"

--- a/internal/resources/aws/elasticache_cluster.go
+++ b/internal/resources/aws/elasticache_cluster.go
@@ -73,7 +73,7 @@ func (r *ElastiCacheCluster) elastiCacheCostComponent(autoscaling bool) *schema.
 		}
 		reservedFilter, err := resolver.PriceFilter()
 		if err != nil {
-			log.Warnf(err.Error())
+			log.Warnf("%s", err.Error())
 		} else {
 			priceFilter = reservedFilter
 		}

--- a/internal/resources/aws/instance.go
+++ b/internal/resources/aws/instance.go
@@ -184,7 +184,7 @@ func (a *Instance) computeCostComponent() *schema.CostComponent {
 		}
 		reservedFilter, err := resolver.PriceFilter()
 		if err != nil {
-			log.Warnf(err.Error())
+			log.Warnf("%s", err.Error())
 		} else {
 			priceFilter = reservedFilter
 		}

--- a/internal/resources/aws/rds_cluster_instance.go
+++ b/internal/resources/aws/rds_cluster_instance.go
@@ -53,7 +53,7 @@ func (r *RDSClusterInstance) BuildResource() *schema.Resource {
 		}
 		priceFilter, err = resolver.PriceFilter()
 		if err != nil {
-			log.Warnf(err.Error())
+			log.Warnf("%s", err.Error())
 		}
 		purchaseOptionLabel = "reserved"
 	}

--- a/internal/resources/aws/s3_bucket.go
+++ b/internal/resources/aws/s3_bucket.go
@@ -160,7 +160,7 @@ func (a *S3Bucket) BuildResource() *schema.Resource {
 			if err != nil {
 				msg = fmt.Sprintf("%s: %s", msg, err)
 			}
-			log.Debugf(msg)
+			log.Debugf("%s", msg)
 		} else {
 			standardStorageClassUsage := u["standard"].(map[string]interface{})
 

--- a/internal/resources/aws/s3_bucket_lifececycle_configuration.go
+++ b/internal/resources/aws/s3_bucket_lifececycle_configuration.go
@@ -148,7 +148,7 @@ func (r *S3BucketLifecycleConfiguration) BuildResource() *schema.Resource {
 			if err != nil {
 				msg = fmt.Sprintf("%s: %s", msg, err)
 			}
-			log.Debugf(msg)
+			log.Debugf("%s", msg)
 		} else {
 			standardStorageClassUsage := u["standard"].(map[string]interface{})
 

--- a/internal/resources/ibm/code_engine_job.go
+++ b/internal/resources/ibm/code_engine_job.go
@@ -1,7 +1,6 @@
 package ibm
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/infracost/infracost/internal/resources"
@@ -55,7 +54,7 @@ func (r *CodeEngineJob) CodeEngineJobVirtualProcessorCoreCostComponent() *schema
 	}
 
 	return &schema.CostComponent{
-		Name:            fmt.Sprintf("Virtual Processor Cores Hours"),
+		Name:            "Virtual Processor Cores Hours",
 		Unit:            "vCPU Hours",
 		UnitMultiplier:  decimal.NewFromInt(1),
 		MonthlyQuantity: ih,
@@ -81,7 +80,7 @@ func (r *CodeEngineJob) CodeEngineJobRAMCostComponent() *schema.CostComponent {
 		trimmedMemory := r.Memory[:len(r.Memory)-1]
 		memGB, _ = strconv.ParseFloat(trimmedMemory, 64)
 		if string(r.Memory[len(r.Memory)-1]) == "M" {
-			memGB = memGB / float64(1024)
+			memGB /= float64(1024)
 		}
 	} else {
 		memGB = float64(4) // Default 4GB
@@ -98,7 +97,7 @@ func (r *CodeEngineJob) CodeEngineJobRAMCostComponent() *schema.CostComponent {
 	}
 
 	return &schema.CostComponent{
-		Name:            fmt.Sprintf("RAM Hours"),
+		Name:            "RAM Hours",
 		Unit:            "GB Hours",
 		UnitMultiplier:  decimal.NewFromInt(1),
 		MonthlyQuantity: ih,

--- a/internal/resources/ibm/is_instance.go
+++ b/internal/resources/ibm/is_instance.go
@@ -136,23 +136,44 @@ func (r *IsInstance) imageHoursCostComponent() *schema.CostComponent {
 	if r.MonthlyInstanceHours != nil {
 		q = decimalPtr(decimal.NewFromFloat(*r.MonthlyInstanceHours))
 	}
-	return &schema.CostComponent{
-		Name:            fmt.Sprintf("Image (%s)", r.Vendor),
-		Unit:            "Hours",
-		UnitMultiplier:  decimal.NewFromInt(1),
-		MonthlyQuantity: q,
-		ProductFilter: &schema.ProductFilter{
-			VendorName:    strPtr("ibm"),
-			Region:        strPtr(r.Region),
-			Service:       strPtr("is.instance"),
-			ProductFamily: strPtr("service"),
-			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "planName", Value: strPtr("gen2-instance-dedicated-host")},
+
+	// If the unit is one of the Vendors above, then look into our database and grab the price
+	if unit != "" {
+		return &schema.CostComponent{
+			Name:            fmt.Sprintf("Image (%s)", r.Vendor),
+			Unit:            "Hours",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: q,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("ibm"),
+				Region:        strPtr(r.Region),
+				Service:       strPtr("is.instance"),
+				ProductFamily: strPtr("service"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "planName", Value: strPtr("gen2-instance-dedicated-host")},
+				},
 			},
-		},
-		PriceFilter: &schema.PriceFilter{
-			Unit: strPtr(unit),
-		},
+			PriceFilter: &schema.PriceFilter{
+				Unit: strPtr(unit),
+			},
+		}
+	} else {
+		costComponent := schema.CostComponent{
+			Name:            "Free Provided Image",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("ibm"),
+				Region:        strPtr(r.Region),
+				Service:       strPtr("is.instance"),
+				ProductFamily: strPtr("service"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "planName", Value: strPtr("provided_image")},
+				},
+			},
+		}
+		costComponent.SetCustomPrice(decimalPtr(decimal.NewFromInt(0)))
+		return &costComponent
 	}
 }
 

--- a/internal/resources/ibm/is_instance.go
+++ b/internal/resources/ibm/is_instance.go
@@ -159,7 +159,7 @@ func (r *IsInstance) imageHoursCostComponent() *schema.CostComponent {
 		}
 	} else {
 		costComponent := schema.CostComponent{
-			Name:            "Free Provided Image",
+			Name:            "Custom Image",
 			UnitMultiplier:  decimal.NewFromInt(1),
 			MonthlyQuantity: decimalPtr(decimal.NewFromInt(1)),
 			ProductFilter: &schema.ProductFilter{

--- a/internal/resources/ibm/is_share.go
+++ b/internal/resources/ibm/is_share.go
@@ -112,7 +112,7 @@ func (r *IsShare) transmittedDataCostComponent() *schema.CostComponent {
 	}
 
 	return &schema.CostComponent{
-		Name:            fmt.Sprintf("Transmitted data"),
+		Name:            "Transmitted data",
 		Unit:            "GB",
 		UnitMultiplier:  decimal.NewFromInt(1),
 		MonthlyQuantity: transmittedQ,

--- a/internal/resources/ibm/resource_instance_logs.go
+++ b/internal/resources/ibm/resource_instance_logs.go
@@ -7,7 +7,7 @@ import (
 
 func GetLogsCostComponents(r *ResourceInstance) []*schema.CostComponent {
 	return []*schema.CostComponent{
-		//cost component functions go here
+		// Cost component functions go here
 		LogsStoreNSearchCostComponent(r),
 		LogsAnalyzeNAlertCostComponent(r),
 		LogsPriorityInsightsCostComponent(r, "PRIORITY_INSIGHTS_RETENTION_SEVEN_DAYS", "7"),

--- a/internal/resources/ibm/resource_instance_pm20.go
+++ b/internal/resources/ibm/resource_instance_pm20.go
@@ -88,7 +88,8 @@ func GetWMLCostComponents(r *ResourceInstance) []*schema.CostComponent {
 			WMLEssentialsCapacityUnitHoursCostComponent(r),
 			WMLMistralLargeOutputResourceUnitsCostComponent(r),
 			WMLTextExtractionCatOneResourceUnitsCostComponent(r),
-			WMLTextExtractionCatTwoResourceUnitsCostComponent(r, "PAGES_CATAGORY_TWO"),
+			// the unit name is spelled wrong for the standard plan
+			WMLTextExtractionCatTwoResourceUnitsCostComponent(r, "PAGES_CATAGORY_TWO"), //nolint:misspell
 			WMLIBMModelResourceUnitsCostComponent(r),
 			WML3rdPartyModelResourceUnitsCostComponent(r),
 			WMLMistralLargeInputResourceUnitsCostComponent(r),

--- a/internal/schema/diff.go
+++ b/internal/schema/diff.go
@@ -200,8 +200,8 @@ func diffCostComponents(past *CostComponent, current *CostComponent) (bool, *Cos
 	// - Tier parameters changed - diff for every field
 	// - Tiered -> not tiered - should be already handled by the code above
 	// - Not tiered -> tiered
-	if current.priceTiers != nil && len(current.priceTiers) > 0 {
-		if past.priceTiers != nil && len(past.priceTiers) > 0 {
+	if len(current.priceTiers) > 0 {
+		if len(past.priceTiers) > 0 {
 			tiersLen := len(current.priceTiers)
 			if len(past.priceTiers) > tiersLen {
 				tiersLen = len(past.priceTiers)

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -175,7 +175,7 @@ func AssertGoldenFile(t *testing.T, goldenFilePath string, actual []byte) {
 
 			err := os.WriteFile(goldenFilePath, actual, 0600)
 			assert.NoError(t, err)
-			t.Logf(fmt.Sprintf("Wrote golden file %s", goldenFilePath))
+			t.Logf("%s", fmt.Sprintf("Wrote golden file %s", goldenFilePath))
 		} else {
 			// Generate the diff and error message.  We don't call assert.Equal because it escapes
 			// newlines (\n) and the output looks terrible.
@@ -189,7 +189,7 @@ func AssertGoldenFile(t *testing.T, goldenFilePath string, actual []byte) {
 				Context:  1,
 			})
 
-			t.Errorf(fmt.Sprintf("\nOutput does not match golden file: \n\n%s\n", diff))
+			t.Errorf("%s", fmt.Sprintf("\nOutput does not match golden file: \n\n%s\n", diff))
 		}
 	}
 }

--- a/tools/release/main.go
+++ b/tools/release/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,7 +54,7 @@ func createDraftRelease(cli *github.Client) (*github.RepositoryRelease, error) {
 		},
 	)
 	if err != nil {
-		b, _ := ioutil.ReadAll(res.Body)
+		b, _ := io.ReadAll(res.Body)
 		return nil, fmt.Errorf("body: %s status: %d %w", b, res.StatusCode, err)
 	}
 


### PR DESCRIPTION
This commit goes over all errors in the `Go` workflow and fixes this. This includes:
1. Updating go files so that all go lint errors are gone
2. Updating golden files so that all unit tests pass
3. Remove unnecessary linters in `.golangci.yml`

## To test:
1. Checkout my branch and rename it  
git checkout -b bugfix/314_fix_golintcli_test origin/bugfix/314_fix_golintcli

2. Push the branch to the infracost repo

3. Create a PR that merges the branch to master
4. Go to `Actions` tab and then press the `Go` workflow
5. Verify that all jobs pass
6. Delete the remote branch

Note: The reason why we have to do 1-3 is because GitHub actions won't share the repo secrets to a forked repo, which is why we must first create a remote branch to our Infracost repo.
https://docs.github.com/en/actions/how-tos/security-for-github-actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow