### PR TITLE
output version info when run

### DIFF
--- a/cmd/infracost/main.go
+++ b/cmd/infracost/main.go
@@ -76,8 +76,6 @@ func Run(modifyCtx func(*config.RunContext), args *[]string) {
 		}
 	}()
 
-	startUpdateCheck(ctx, updateMessageChan)
-
 	rootCmd := newRootCmd(ctx)
 	if args != nil {
 		rootCmd.SetArgs(*args)
@@ -226,17 +224,6 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 	return rootCmd
 }
 
-func startUpdateCheck(ctx *config.RunContext, c chan *update.Info) {
-	go func() {
-		updateInfo, err := update.CheckForUpdate(ctx)
-		if err != nil {
-			logging.Logger.WithError(err).Debug("error checking for Infracost CLI update")
-		}
-		c <- updateInfo
-		close(c)
-	}()
-}
-
 func loadCloudSettings(ctx *config.RunContext) {
 	if ctx.Config.IsSelfHosted() || (ctx.Config.EnableCloud != nil && !*ctx.Config.EnableCloud) {
 		return
@@ -294,17 +281,8 @@ func handleUnexpectedErr(ctx *config.RunContext, err error) {
 }
 
 func handleUpdateMessage(updateMessageChan chan *update.Info) {
-	updateInfo := <-updateMessageChan
-	if updateInfo != nil {
-		msg := fmt.Sprintf("\n%s %s %s → %s\n%s\n",
-			ui.WarningString("Update:"),
-			"A new version of Infracost is available:",
-			ui.PrimaryString(version.Version),
-			ui.PrimaryString(updateInfo.LatestVersion),
-			ui.Indent(updateInfo.Cmd, "  "),
-		)
-		fmt.Fprint(os.Stderr, msg)
-	}
+	msg := fmt.Sprintf("\n%s %s", "version:", ui.PrimaryString(version.Version))
+	fmt.Fprint(os.Stderr, msg)
 }
 
 func loadGlobalFlags(ctx *config.RunContext, cmd *cobra.Command) error {

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -488,6 +488,7 @@ func (r *parallelRunner) runProjectConfig(ctx *config.ProjectContext) (*projectO
 
 	r.buildResources(projects)
 
+	/* DISABLED to reduce noise in logs
 	spinnerOpts := ui.SpinnerOptions{
 		EnableLogging: r.runCtx.Config.IsLogging(),
 		NoColor:       r.runCtx.Config.NoColor,
@@ -495,10 +496,11 @@ func (r *parallelRunner) runProjectConfig(ctx *config.ProjectContext) (*projectO
 	}
 	spinner := ui.NewSpinner("Retrieving cloud prices to calculate costs", spinnerOpts)
 	defer spinner.Fail()
+	*/
 
 	for _, project := range projects {
 		if err := prices.PopulatePrices(r.runCtx, project); err != nil {
-			spinner.Fail()
+			// spinner.Fail()
 			r.cmd.PrintErrln()
 
 			if e := unwrapped(err); errors.Is(e, apiclient.ErrInvalidAPIKey) {
@@ -535,7 +537,7 @@ func (r *parallelRunner) runProjectConfig(ctx *config.ProjectContext) (*projectO
 	// wait for the hcl provider to finish if it hasn't already
 	wg.Wait()
 
-	spinner.Success()
+	// spinner.Success()
 
 	if r.runCtx.Config.UsageActualCosts {
 		r.populateActualCosts(projects)

--- a/scripts/get_version.sh
+++ b/scripts/get_version.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 COMMITISH=${1:-HEAD}
-NO_DIRTY=${2:-false}
+NO_DIRTY=${2:-true}
 TAG=""
 BUILD=""
 DIRTY_SUFFIX=""


### PR DESCRIPTION
The version check which isn't used has been updated to always output the version info, instead of checking home for the latest version.